### PR TITLE
Fix rummager notification

### DIFF
--- a/app/listeners/rummager_notifier.rb
+++ b/app/listeners/rummager_notifier.rb
@@ -8,6 +8,8 @@ class RummagerNotifier
     query_field = "#{match_type}_query".to_sym
 
     es_doc = {
+      _id: "#{query}-#{match_type}",
+      _type: 'best_bet',
       query_field => query,
       details: {
         best_bets: [],

--- a/features/support/best_bets.rb
+++ b/features/support/best_bets.rb
@@ -45,13 +45,17 @@ end
 def check_rummager_was_sent_an_exact_best_bet_document(best_bets)
   positive_bets, negative_bets = best_bets.partition(&:position)
 
+  representative_bet = best_bets.first
+
   details_json = {
     best_bets: positive_bets.map {|bet| {link: bet.link, position: bet.position} },
     worst_bets: negative_bets.map {|bet| {link: bet.link} }
   }.to_json
 
   elasticsearch_doc = {
-    exact_query: best_bets.first.query,
+    _id: "#{representative_bet.query}-#{representative_bet.match_type}",
+    _type: 'best_bet',
+    exact_query: representative_bet.query,
     details: details_json
   }
 

--- a/spec/listeners/rummager_notifier_spec.rb
+++ b/spec/listeners/rummager_notifier_spec.rb
@@ -28,6 +28,8 @@ describe RummagerNotifier do
       }.to_json
 
       expect(SearchAdmin.services(:rummager_index)).to have_received(:add).with({
+        _id: 'jobs-exact',
+        _type: 'best_bet',
         exact_query: 'jobs',
         details: details_json
       })


### PR DESCRIPTION
- Send best bet details to elasticsearch as JSON.
  - ES should not be parsing this field as we have and need no schema for it.
- Send the `_id` and `_type` to Rummager.
  - This allows it to use the correct schema when importing the document.
