### PR TITLE
Bump the jtw gem in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
     hike (1.2.3)
     i18n (0.6.9)
     json (1.8.1)
-    jwt (0.1.12)
+    jwt (0.1.13)
     kgio (2.9.2)
     launchy (2.4.2)
       addressable (~> 2.3)


### PR DESCRIPTION
The previous gem version had been yanked, which was stopping bundler from running properly. Incrementing to the next patch release fixes this.
