### PR TITLE
Sort best bets in query/match-type/position order

### DIFF
--- a/app/controllers/best_bets_controller.rb
+++ b/app/controllers/best_bets_controller.rb
@@ -2,7 +2,7 @@ class BestBetsController < ApplicationController
   before_filter :find_best_bet, only: [:edit, :update, :destroy]
 
   def index
-    @best_bets = BestBet.all
+    @best_bets = BestBet.in_query_order
 
     respond_to do |format|
       format.html

--- a/app/models/best_bet.rb
+++ b/app/models/best_bet.rb
@@ -16,6 +16,10 @@ class BestBet < ActiveRecord::Base
                          only_integer: true
                        }
 
+  scope :in_query_order, -> { order(query: :asc,
+                                    match_type: :asc,
+                                    position: :asc) }
+
   def self.to_csv(*args)
     CSV.generate do |csv|
       csv << ['query', 'link']


### PR DESCRIPTION
When best bets are displayed in the list, sort them by the query first, then the match type, and then the position.
