### PR TITLE
Fix javascript appearing before DOCTYPE

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,5 @@
 <% content_for :head do %>
   <%= stylesheet_link_tag "application", :media => "all" %>
-  <%= javascript_include_tag 'application' %>
   <%= csrf_meta_tags %>
 <% end %>
 
@@ -21,11 +20,15 @@
   <% end -%>
   <%= yield %>
 <% end %>
+
+<% content_for :body_end do %>
 <%= javascript_include_tag "application" %>
 <script>
   $(document).ready(function() {
     <%= yield :document_ready %>
   });
 </script>
+<% end %>
+
 <%# use the govuk_admin_foundation layout %>
 <%= render :template => 'layouts/govuk_admin_template' %>


### PR DESCRIPTION
Put the javascript_include_tag and the inline script in body_end; they'd
accidentally not been put in a content block, and so were appearing
outside the content at the top of the HTTP response.

Remove the duplicate javascript_include_tag from head.
