### PR TITLE
Upgrade Bootstrap to 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'mysql2'
 gem 'gds-sso', '9.3.0'
 gem 'rummageable', '1.2.0'
 
-gem 'govuk_admin_template', '1.1.6'
+gem 'govuk_admin_template', '1.4.0'
 
 gem 'sass-rails', '~> 4.0.3'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
       builder
       multi_json
     arel (5.0.1.20140414130214)
-    bootstrap-sass (3.2.0.2)
+    bootstrap-sass (3.3.1.0)
       sass (~> 3.2)
     builder (3.2.2)
     byebug (3.1.2)
@@ -81,8 +81,8 @@ GEM
     generic_form_builder (0.8.0)
     gherkin (2.12.2)
       multi_json (~> 1.3)
-    govuk_admin_template (1.1.6)
-      bootstrap-sass (~> 3.2.0.2)
+    govuk_admin_template (1.4.0)
+      bootstrap-sass (~> 3.3.1)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
     hashie (3.2.0)
@@ -214,7 +214,7 @@ DEPENDENCIES
   factory_girl_rails
   gds-sso (= 9.3.0)
   generic_form_builder (= 0.8.0)
-  govuk_admin_template (= 1.1.6)
+  govuk_admin_template (= 1.4.0)
   launchy
   mysql2
   plek (= 1.7.0)


### PR DESCRIPTION
Bump admin gem to pick up Bootstrap 3.3 (see https://github.com/alphagov/govuk_admin_template/pull/53)
For testing, everything on this branch should look and behave as it did before.

https://www.agileplannerapp.com/boards/173808/cards/8764
