### PR TITLE
Fix N+1 query on Query collection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,10 @@ gem 'generic_form_builder', '0.8.0'
 
 gem 'byebug', group: [:development, :test]
 
+group :development do
+  gem 'quiet_assets'
+end
+
 group :test do
   gem 'rspec-rails'
   gem 'rspec-core', '2.14.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     plek (1.7.0)
+    quiet_assets (1.1.0)
+      railties (>= 3.1, < 5.0)
     rack (1.5.2)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -218,6 +220,7 @@ DEPENDENCIES
   launchy
   mysql2
   plek (= 1.7.0)
+  quiet_assets
   rails (= 4.1.8)
   rspec-core (= 2.14.8)
   rspec-rails

--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -2,7 +2,7 @@ class QueriesController < ApplicationController
   include Notifiable
 
   def index
-    @queries = Query.all.order([:query, :match_type])
+    @queries = Query.includes(:best_bets, :worst_bets).order([:query, :match_type])
 
     respond_to do |format|
       format.html

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -9,6 +9,8 @@ class Query < ActiveRecord::Base
   validates :query, uniqueness: {scope: :match_type}
 
   has_many :bets, dependent: :destroy
+  has_many :best_bets, -> { best }, class: Bet
+  has_many :worst_bets, -> { worst }, class: Bet
 
   def self.to_csv(*args)
     CSV.generate do |csv|
@@ -20,13 +22,5 @@ class Query < ActiveRecord::Base
         end
       end
     end
-  end
-
-  def best_bets
-    bets.best
-  end
-
-  def worst_bets
-    bets.worst
   end
 end


### PR DESCRIPTION
Currently Rails is doing two SELECTs for each item in the query-list on the landing page of this app. And there are a lot of items.

This commit refactors adds `best_bests` and `worst_bests` associations for Query. This allows an `includes` to prevent the N+1 query.

Before: ActiveRecord: 365.1ms
After: ActiveRecord: 10.7ms