### PR TITLE
Fix display of worst bet list

### DIFF
--- a/app/views/queries/index.html.erb
+++ b/app/views/queries/index.html.erb
@@ -27,11 +27,11 @@
           </ol>
         </td>
         <td>
-          <ul>
+          <ol>
             <% query.worst_bets.each do |bet| %>
               <li><%= bet.link %></li>
             <% end %>
-          </ul>
+          </ol>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
Worst bets currently aren't being given the appropriate list styling on
the list page in search admin.  The bullet points should be removed and
indenting fixed.

Trello: https://trello.com/c/4oqIRQij/88-search-admin-style-worst-bets-properly-on-list-page