### PR TITLE
Show best bet links in order

### DIFF
--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -34,7 +34,7 @@ class QueriesController < ApplicationController
     @new_bet = Bet.new
 
     @query = find_query
-    @best_bets = @query.best_bets
+    @best_bets = @query.sorted_best_bets
     @worst_bets = @query.worst_bets
   end
 

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -12,6 +12,11 @@ class Query < ActiveRecord::Base
   has_many :best_bets, -> { best }, class: Bet
   has_many :worst_bets, -> { worst }, class: Bet
 
+  # Use `sort_by` to prevent N+1 queries when Queries are loaded in a list.
+  def sorted_best_bets
+    best_bets.sort_by(&:position)
+  end
+
   def self.to_csv(*args)
     CSV.generate do |csv|
       csv << ['query', 'link']

--- a/app/views/queries/index.html.erb
+++ b/app/views/queries/index.html.erb
@@ -21,7 +21,7 @@
         <td><%= link_to query.match_type, query_path(query) %></td>
         <td>
           <ol>
-            <% query.best_bets.each do |bet| %>
+            <% query.sorted_best_bets.each do |bet| %>
               <li><%= bet.link %></li>
             <% end %>
           </ol>

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -1,5 +1,20 @@
 require 'spec_helper'
 
+describe Query do
+  describe '#sorted_best_bets' do
+    it "sorts the best bets by position" do
+      query = FactoryGirl.create(:query)
+      FactoryGirl.create(:bet, query: query, position: 3)
+      FactoryGirl.create(:bet, query: query, position: 1)
+      FactoryGirl.create(:bet, query: query, position: 2)
+
+      list = query.sorted_best_bets
+
+      expect(list.map(&:position)).to eql [1, 2, 3]
+    end
+  end
+end
+
 describe Query, 'associations' do
   it 'should destroy associated bets on #destroy' do
     query = FactoryGirl.create :query


### PR DESCRIPTION
Currently, the list of best bets is shown in DB order, not in order of
position. This happens both on the main list of best bets and in the
list for a particular query.

In the list view we have to use `sort_by` because the bets have been eager-loaded with the query.

https://trello.com/c/Tk9QCE1i