### PR TITLE
Remove side effects in Query factory

### DIFF
--- a/features/step_definitions/best_bet_steps.rb
+++ b/features/step_definitions/best_bet_steps.rb
@@ -29,7 +29,7 @@ Then(/^the best bet should be listed on the query page$/) do
 end
 
 Given(/^a query exists$/) do
-  @query = FactoryGirl.create(:query)
+  @query = FactoryGirl.create(:query, :with_best_bet)
   @query.bets.each {|b| b.update_attribute(:link, '/jobsearch') }
 end
 
@@ -41,17 +41,15 @@ end
 
 Given(/^a variety of best bets exist$/) do
   jobs_query = FactoryGirl.create(:query, query: "jobs", match_type: "exact")
-  jobs_query.bets.destroy_all
   FactoryGirl.create(:bet, :best, query: jobs_query, link: "/jobs-1", position: 1)
   FactoryGirl.create(:bet, :best, query: jobs_query, link: "/jobs-2", position: 2)
 
   visas_query = FactoryGirl.create(:query, query: "visas", match_type: "exact")
-  visas_query.bets.destroy_all
   FactoryGirl.create(:bet, :worst, query: visas_query, link: "/a-bad-visas-page")
 end
 
 Given(/^a query with a worst bet exists$/) do
-  query = FactoryGirl.create(:query, query: "worst-bet", match_type: "exact")
+  query = FactoryGirl.create(:query, :with_best_bet, query: "worst-bet", match_type: "exact")
   FactoryGirl.create(:bet, :worst, query: query, link: "/worst-bet", position: nil, comment: 'a comment')
 end
 

--- a/spec/controllers/bets_controller_spec.rb
+++ b/spec/controllers/bets_controller_spec.rb
@@ -57,6 +57,7 @@ describe BetsController do
   end
 
   describe "Updating bets" do
+    let(:query) { FactoryGirl.create(:query, :with_best_bet) }
     let(:bet) { query.bets.first }
 
     it "notifies the world of the change to the query" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -22,8 +22,10 @@ FactoryGirl.define do
     query "tax"
     match_type "exact"
 
-    after(:create) do |query|
-      create(:bet, :best, query: query)
+    trait :with_best_bet do
+      after(:create) do |query|
+        create(:bet, :best, query: query)
+      end
     end
   end
 

--- a/spec/listeners/rummager_notifier_spec.rb
+++ b/spec/listeners/rummager_notifier_spec.rb
@@ -5,6 +5,8 @@ describe RummagerNotifier do
     let(:query) { FactoryGirl.create(:query, query: 'jobs', match_type: 'exact') }
 
     it "`add`s an elasticsearch doc for existing queries" do
+      query = FactoryGirl.create(:query, :with_best_bet, query: 'jobs', match_type: 'exact')
+
       es_doc_body = double(:es_doc_body)
       es_doc = double(:es_doc, body: es_doc_body)
       expect(ElasticSearchBet).to receive(:new)
@@ -32,8 +34,6 @@ describe RummagerNotifier do
       expect(ElasticSearchBetIDGenerator).to receive(:generate)
         .with('jobs', 'exact')
         .and_return(es_doc_id)
-
-      query.bets.destroy_all
 
       RummagerNotifier.call([['jobs', 'exact']])
 

--- a/spec/models/elastic_search_bet_spec.rb
+++ b/spec/models/elastic_search_bet_spec.rb
@@ -4,8 +4,6 @@ describe ElasticSearchBet do
   let(:query) { FactoryGirl.create(:query, query: 'jobs', match_type: 'exact') }
 
   before do
-    query.bets.destroy_all
-
     FactoryGirl.create(:bet, :best, link: '/jobs/more-jobs', position: 2, query: query)
     FactoryGirl.create(:bet, :best, link: '/jobsearch', position: 1, query: query)
 


### PR DESCRIPTION
The "default" version of factories should do as little as possible, eg have the minimum of attributes needed to be `valid?`.

This commit moves the creation of a `bet` association to a `with_best_bet` trait.

- Makes the tests more explicit by making the user specify the dependency on having a `best_bet`.
- Speeds up tests that do not need a best bet present.
- Removes the need to `destroy_all` bets to create a Query *without* bets.