### PR TITLE
Improve UX for search-admin

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -53,4 +53,13 @@ form {
 
 form.button_to {
   margin-bottom: 0;
+  display: inline-block;
+}
+
+.actions {
+  margin-bottom: 30px;
+
+  a.btn, input.btn {
+    margin-right: 10px;
+  }
 }

--- a/app/assets/stylesheets/queries/_list.scss
+++ b/app/assets/stylesheets/queries/_list.scss
@@ -4,9 +4,24 @@ table.queries-list {
   @extend .table-bordered;
 
   width: 100%;
+
   ol {
     list-style: none;
     padding: 0;
+  }
+
+  h4 {
+    margin-bottom: 5px;
+  }
+
+  small.comment {
+    color: #8E8E8E;
+    display: block;
+  }
+
+  .glyphicon-minus {
+    color: #CC0000;
+    margin-right: 5px;
   }
 }
 

--- a/app/helpers/buttons_helper.rb
+++ b/app/helpers/buttons_helper.rb
@@ -1,0 +1,8 @@
+module ButtonsHelper
+  def delete_button(text, path)
+    button_to text, path,
+      method: :delete,
+      class: 'btn btn-danger',
+      data: { confirm: 'Are you sure?' }
+  end
+end

--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -1,0 +1,6 @@
+module IconHelper
+  # http://getbootstrap.com/components/#glyphicons-glyphs
+  def icon(icon_name)
+    content_tag :i, '', class: "glyphicon glyphicon-#{icon_name}"
+  end
+end

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -1,0 +1,7 @@
+module TagHelper
+  # Set the page <title> and return the <h1> tag.
+  def page_title(string)
+    content_for :page_title, "#{string} - Search Admin"
+    content_tag :h1, string, class: 'page-title-with-border'
+  end
+end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -17,6 +17,10 @@ class Query < ActiveRecord::Base
     best_bets.sort_by(&:position)
   end
 
+  def display_name
+    "#{query} (#{match_type})"
+  end
+
   def self.to_csv(*args)
     CSV.generate do |csv|
       csv << ['query', 'match_type', 'link', 'best/worst', 'comment']

--- a/app/views/bets/_form.html.erb
+++ b/app/views/bets/_form.html.erb
@@ -1,9 +1,21 @@
 <%= form_for(bet) do |f| %>
-  <%= f.text_field :link %>
-  <%= f.number_field :position %>
-  <%= f.check_box :is_worst, label: 'Is worst bet?' %>
-  <%= f.text_field :comment %>
+  <div class="form-group">
+    <%= f.text_field :link, class: "form-control input-lg" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.number_field :position, class: "form-control input-lg" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.check_box :is_worst, label: 'Is worst bet?' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.text_area :comment, class: "form-control input-lg" %>
+  </div>
+
   <%= f.hidden_field :query_id, value: query.id %>
 
-  <%= f.button "Save", class: 'btn btn-primary' %>
+  <%= f.button "Save", class: "btn btn-success btn-lg" %>
 <% end %>

--- a/app/views/bets/edit.html.erb
+++ b/app/views/bets/edit.html.erb
@@ -1,3 +1,9 @@
-<h1 class="page-title-with-border">Edit best bet</h1>
+<ol class="breadcrumb">
+  <li><%= link_to 'Queries', queries_path %></li>
+  <li><%= link_to @bet.query.display_name, query_path(@bet.query) %></li>
+  <li class="active">Edit '<%= @bet.link %>'</li>
+</ol>
+
+<%= page_title "Edit '#{@bet.link}'" %>
 
 <%= render 'form', bet: @bet, query: @bet.query %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,11 +3,10 @@
   <%= csrf_meta_tags %>
 <% end %>
 
-<% content_for :page_title, "Search Admin" %>
 <% content_for :app_title, "GOV.UK Search Admin" %>
 
 <% content_for :navbar_items do %>
-  <li><%= link_to 'Queries', '/queries' %></li>
+  <li class='active'><%= link_to 'Queries', '/queries' %></li>
 <% end %>
 
 <% content_for :navbar_right do %>

--- a/app/views/queries/_form.html.erb
+++ b/app/views/queries/_form.html.erb
@@ -1,5 +1,11 @@
 <%= form_for(query) do |f| %>
-  <%= f.text_field :query %>
-  <%= f.select :match_type, Query::MATCH_TYPES.map {|t| [t.humanize, t] } %>
-  <%= f.button "Save", class: 'btn btn-primary' %>
+  <div class="form-group">
+    <%= f.text_field :query, class: "form-control input-lg" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.select :match_type, Query::MATCH_TYPES.map { |t| [t.humanize, t] }, class: "form-control input-lg" %>
+  </div>
+
+  <%= f.button "Save", class: "btn btn-success btn-lg" %>
 <% end %>

--- a/app/views/queries/_query_item.html.erb
+++ b/app/views/queries/_query_item.html.erb
@@ -1,0 +1,29 @@
+<tr class="query" id="query-<%= query.id %>">
+  <td><%= link_to query.query, query_path(query) %></td>
+  <td><%= query.match_type %></td>
+  <td>
+    <% if query.sorted_best_bets.any? %>
+      <ol>
+        <% query.sorted_best_bets.each do |bet| %>
+          <li>
+            <%= link_to bet.link, edit_bet_path(bet) %>
+            <% if bet.comment.present? %>
+              <small class='comment'>
+                <%= bet.comment %>
+              </small>
+            <% end %>
+          </li>
+        <% end %>
+      </ol>
+    <% end %>
+
+    <% if query.worst_bets.any? %>
+      <ol>
+        <strong>Worst Bets</strong>
+        <% query.worst_bets.each do |bet| %>
+          <li><%= icon(:minus) %> <%= link_to bet.link, edit_bet_path(bet) %></li>
+        <% end %>
+      </ol>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/queries/edit.html.erb
+++ b/app/views/queries/edit.html.erb
@@ -1,1 +1,9 @@
+<ol class="breadcrumb">
+  <li><%= link_to 'Queries', queries_path %></li>
+  <li><%= link_to @query.display_name, query_path(@query) %></li>
+  <li class="active">Edit</li>
+</ol>
+
+<%= page_title @query.display_name %>
+
 <%= render 'form', query: @query %>

--- a/app/views/queries/index.html.erb
+++ b/app/views/queries/index.html.erb
@@ -1,20 +1,23 @@
-<h1 class="page-title-with-border remove-bottom-margin">Queries</h1>
+<ol class="breadcrumb">
+  <li class="active">Queries</li>
+</ol>
 
-<div class="add-vertical-margins">
-  <%= link_to 'New query', new_query_path, class: 'btn btn-primary add-right-margin'%>
-  <%= link_to 'View as CSV', queries_path(format: 'csv'), class: 'btn btn-default' %>
+<%= page_title 'Queries' %>
+
+<div class="actions">
+  <%= link_to icon(:plus) + ' New query', new_query_path, class: 'btn btn-primary'%>
+  <%= link_to icon(:download) + ' Download CSV', queries_path(format: 'csv'), class: 'btn btn-default' %>
 </div>
 
 <table class="table queries-list table-bordered" data-module="filterable-table">
   <thead>
     <tr class="table-header">
-      <th>Query</th>
+      <th>Term</th>
       <th>Match</th>
-      <th>Best bets</th>
-      <th>Worst bets</th>
+      <th>Bets</th>
     </tr>
 
-    <tr class="table-header">
+    <tr class="table-header if-no-js-hide table-header-secondary">
       <th colspan='4'>
         <form class='table-filter'>
           <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter table">
@@ -24,24 +27,7 @@
   </thead>
   <tbody>
     <% @queries.each do |query| %>
-      <tr class="query" id="query-<%= query.id %>">
-        <td><%= link_to query.query, query_path(query) %></td>
-        <td><%= link_to query.match_type, query_path(query) %></td>
-        <td>
-          <ol>
-            <% query.sorted_best_bets.each do |bet| %>
-              <li><%= bet.link %></li>
-            <% end %>
-          </ol>
-        </td>
-        <td>
-          <ol>
-            <% query.worst_bets.each do |bet| %>
-              <li><%= bet.link %></li>
-            <% end %>
-          </ol>
-        </td>
-      </tr>
+      <%= render 'queries/query_item', query: query %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/queries/new.html.erb
+++ b/app/views/queries/new.html.erb
@@ -1,1 +1,8 @@
+<ol class="breadcrumb">
+  <li><%= link_to 'Queries', queries_path %></li>
+  <li class="active">New query</li>
+</ol>
+
+<%= page_title 'New query' %>
+
 <%= render 'form', query: Query.new %>

--- a/app/views/queries/show.html.erb
+++ b/app/views/queries/show.html.erb
@@ -1,13 +1,16 @@
-<h1><%= @query.query %> - <%= @query.match_type %></h1>
-<p><%= link_to "Edit query", edit_query_path(@query), class: 'btn btn-primary' %></p>
-<p><%= link_to 'Return to query index', queries_path %></p>
-<p><%= delete_button "Delete query", query_path(@query) %></p>
+<ol class="breadcrumb">
+  <li><%= link_to 'Queries', queries_path %></li>
+  <li class="active"><%= @query.display_name %></li>
+</ol>
 
+<%= page_title @query.display_name %>
 
-<h2>Add new bet</h2>
-<%= render 'bets/form', bet: @new_bet, query: @query %>
+<div class="actions">
+  <%= link_to "Edit query", edit_query_path(@query), class: 'btn btn-default' %>
+  <%= delete_button "Delete query", query_path(@query) %>
+</div>
 
-<h2>Best bets</h2>
+<h3>Best bets</h3>
 
 <table class="table best-bets bets-list">
   <thead>
@@ -30,7 +33,7 @@
   </tbody>
 </table>
 
-<h2>Worst bets</h2>
+<h3>Worst bets</h3>
 
 <table class="table worst-bets bets-list">
   <thead>
@@ -50,3 +53,6 @@
   <% end %>
   </tbody>
 </table>
+
+<h3>Add new bet</h3>
+<%= render 'bets/form', bet: @new_bet, query: @query %>

--- a/app/views/queries/show.html.erb
+++ b/app/views/queries/show.html.erb
@@ -1,7 +1,8 @@
 <h1><%= @query.query %> - <%= @query.match_type %></h1>
 <p><%= link_to "Edit query", edit_query_path(@query), class: 'btn btn-primary' %></p>
-<p><%= button_to "Delete query", query_path(@query), method: :delete, class: 'btn btn-danger' %></p>
 <p><%= link_to 'Return to query index', queries_path %></p>
+<p><%= delete_button "Delete query", query_path(@query) %></p>
+
 
 <h2>Add new bet</h2>
 <%= render 'bets/form', bet: @new_bet, query: @query %>
@@ -23,7 +24,7 @@
       <td><%= link_to bet.link, edit_bet_path(bet) %></td>
       <td><%= bet.position %></td>
       <td><%= bet.comment %></td>
-      <td><%= button_to 'Delete', bet_path(bet), method: :delete, class: 'btn btn-danger' %></td>
+      <td><%= delete_button 'Delete', bet_path(bet) %></td>
     </tr>
   <% end %>
   </tbody>
@@ -44,7 +45,7 @@
     <tr class="bet" id="bet-<%= bet.id %>">
       <td><%= link_to bet.link, edit_bet_path(bet) %></td>
       <td><%= bet.comment %></td>
-      <td><%= button_to 'Delete', bet_path(bet), method: :delete, class: 'btn btn-danger' %></td>
+      <td><%= delete_button 'Delete', bet_path(bet) %></td>
     </tr>
   <% end %>
   </tbody>

--- a/features/step_definitions/best_bet_csv_steps.rb
+++ b/features/step_definitions/best_bet_csv_steps.rb
@@ -1,7 +1,7 @@
 When(/^I view the best bets CSV$/) do
   visit queries_path
 
-  click_on 'View as CSV'
+  click_on 'Download CSV'
 end
 
 Then(/^I should see all best bets listed in the CSV$/) do

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -4,6 +4,9 @@ Given(/^I am viewing a specific query$/) do
 end
 
 Then(/^I can click a link to navigate to the index$/) do
-  click_link 'Return to query index'
+  within(".breadcrumb") do
+    click_link 'Queries'
+  end
+
   expect(current_path).to eq queries_path
 end


### PR DESCRIPTION
General tidying-up of the interface.

- Improve layout of query list view (together with @tarastockford)
- Add correct page `<titles>` and `<h1>` tags for all pages
- Add breadcrumbs for all pages
- Make the navigation bar look `active`
- Make all forms bootstrap-styled
- Respect admin styleguide (specifically `btn-success` for save)
- Put buttons in right place

### Trello tickets:

https://trello.com/c/3FqslLiL/86-search-admin-show-comment-fields-on-list-page

### Before / after

![before](https://cloud.githubusercontent.com/assets/233676/7563658/fcf88cbe-f7d6-11e4-886d-5ec947d3e52b.png)

![after](https://cloud.githubusercontent.com/assets/233676/7563657/fcf71b04-f7d6-11e4-826c-b5f56d3b8986.png)

