### PR TITLE
Show iframe with search results on query page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,9 @@
 //= require jquery
 //= require jquery_ujs
+
+// The Bets page contains a button to refresh the iframe.
+$('#search-results-refresh').on('click', function () {
+  var iframe = document.getElementById('search-results');
+  iframe.src = iframe.src;
+  return false;
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,3 +9,4 @@
 
 @import "bets/list";
 @import "queries/list";
+@import "queries/show";

--- a/app/assets/stylesheets/queries/_show.scss
+++ b/app/assets/stylesheets/queries/_show.scss
@@ -1,0 +1,5 @@
+#search-results {
+  width: 100%;
+  height: 1000px;
+  border: 1px solid #000;
+}

--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -36,6 +36,8 @@ class QueriesController < ApplicationController
     @query = find_query
     @best_bets = @query.sorted_best_bets
     @worst_bets = @query.worst_bets
+
+    @search_url = SearchUrl.for(@query.query)
   end
 
   def edit

--- a/app/services/search_url.rb
+++ b/app/services/search_url.rb
@@ -1,0 +1,8 @@
+class SearchUrl
+  def self.for(search_term)
+    base_url = Plek.current.find('www')
+    search_term = CGI::escape(search_term)
+    random = SecureRandom.hex(10)
+    "#{base_url}/search?q=#{search_term}&debug_score=1&cachebust=#{random}"
+  end
+end

--- a/app/views/queries/show.html.erb
+++ b/app/views/queries/show.html.erb
@@ -56,3 +56,16 @@
 
 <h3>Add new bet</h3>
 <%= render 'bets/form', bet: @new_bet, query: @query %>
+
+<h3>Search results</h3>
+<%= link_to 'Visit URL', @search_url, target: '_blank' %>
+
+<div class='callout callout-info add-bottom-margin'>
+  <div class="callout-title">
+    There is a slight delay between the updating of a bet and the indexing
+    by the search engine. If you're seeing unexpected results,
+    <a href='' id='search-results-refresh'>try refreshing these results</a>.
+  </div>
+</div>
+
+<iframe src="<%= @search_url %>" id="search-results"></iframe>

--- a/features/queries.feature
+++ b/features/queries.feature
@@ -3,6 +3,11 @@ Feature: Queries
   I want to be able to create queries which hold bets
   So that I can organise my bets in a clearer way
 
+  Scenario: Viewing a query
+    When I create a new query
+    And I visit the query
+    Then I should see the search results on the page
+
   Scenario: Creating a query
     When I create a new query
     Then the query should be listed on the query index

--- a/features/step_definitions/query_steps.rb
+++ b/features/step_definitions/query_steps.rb
@@ -21,3 +21,12 @@ end
 Then(/^the query should not be listed on the query index$/) do
   check_for_absence_of_query_on_index_page(query: @query.query, match_type: @query.match_type)
 end
+
+When(/^I visit the query$/) do
+  visit query_path(@query || Query.last)
+end
+
+Then(/^I should see the search results on the page$/) do
+  expect(page).to have_selector('iframe')
+  expect(find('iframe')[:src]).to include 'gov.uk/search?q=jobs'
+end


### PR DESCRIPTION
To make it easier to see the effects of best/worst bets, we add an iframe with the actual search results on the query page. The iframe embeds the `gov.uk/search` page.

After a best bet is deleted and added it can take a little time (a second or so) before elasticsearch returns the correct results. The iframe is therefore not guaranteed to be current after an update. This is mitigated by adding a callout with a warning and a button to refresh the iframe.

### Screenshot

![screen shot 2015-05-13 at 14 45 27](https://cloud.githubusercontent.com/assets/233676/7611816/cd794790-f97e-11e4-87e7-2fec5e3a843c.png)
