### PR TITLE
Fix iframe refresh + other follow ups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '4.1.8'
 
 gem 'unicorn'
 gem "airbrake", "3.1.16"
-gem "plek", "1.7.0"
+gem 'plek', '~> 1.10.0'
 
 gem 'mysql2'
 gem 'gds-sso', '9.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
       multi_json (~> 1.3)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    plek (1.7.0)
+    plek (1.10.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.5.3)
@@ -223,7 +223,7 @@ DEPENDENCIES
   govuk_admin_template (~> 2.2.0)
   launchy
   mysql2
-  plek (= 1.7.0)
+  plek (~> 1.10.0)
   quiet_assets
   rails (= 4.1.8)
   rspec-core (= 2.14.8)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,9 +1,3 @@
 //= require jquery
 //= require jquery_ujs
-
-// The Bets page contains a button to refresh the iframe.
-$('#search-results-refresh').on('click', function () {
-  var iframe = document.getElementById('search-results');
-  iframe.src = iframe.src;
-  return false;
-});
+//= require best_bets

--- a/app/assets/javascripts/best_bets.js
+++ b/app/assets/javascripts/best_bets.js
@@ -1,0 +1,19 @@
+(function () {
+  // The Bets page contains a button to refresh the iframe.
+  $('#search-results-refresh').on('click', refreshSearchResults);
+
+  function refreshSearchResults(argument) {
+    var iframe = document.getElementById('search-results');
+    var currentCacheBust = findParameterInUrl(iframe.src, 'cachebust');
+    var newCacheBust = (new Date()).getTime();
+
+    iframe.src = iframe.src.replace(currentCacheBust, newCacheBust);
+
+    return false;
+  }
+
+  function findParameterInUrl(url, name) {
+    var match = RegExp('[?&]' + name + '=([^&]*)').exec(url);
+    return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
+  }
+})();

--- a/app/assets/stylesheets/queries/_list.scss
+++ b/app/assets/stylesheets/queries/_list.scss
@@ -1,6 +1,5 @@
 table.queries-list {
   @extend .table;
-  @extend .table-striped;
   @extend .table-bordered;
 
   width: 100%;

--- a/app/services/search_url.rb
+++ b/app/services/search_url.rb
@@ -1,6 +1,6 @@
 class SearchUrl
   def self.for(search_term)
-    base_url = Plek.current.find('www')
+    base_url = Plek.current.website_root
     search_term = CGI::escape(search_term)
     random = SecureRandom.hex(10)
     "#{base_url}/search?q=#{search_term}&debug_score=1&cachebust=#{random}"

--- a/app/views/queries/_query_item.html.erb
+++ b/app/views/queries/_query_item.html.erb
@@ -19,7 +19,7 @@
 
     <% if query.worst_bets.any? %>
       <ol>
-        <strong>Worst Bets</strong>
+        <strong>Worst bets</strong>
         <% query.worst_bets.each do |bet| %>
           <li><%= icon(:minus) %> <%= link_to bet.link, edit_bet_path(bet) %></li>
         <% end %>


### PR DESCRIPTION
Minor PR to follow up on a couple of recent changes:

- Because the cache busting query string is always the same, clicking
refresh won't actually refresh the results. This changes the value of `cachebust=` in the URL each time the refresh button is hit. Follow up to https://github.com/alphagov/search-admin/pull/31

- Use `website_root` to generate URLs. Follow up to https://github.com/alphagov/search-admin/pull/31

- Some styling and spelling changes proposed by @tarastockford