### PR TITLE
Bump sass to 3.4 and fix glyphicons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'rummageable', '1.2.0'
 
 gem 'govuk_admin_template', '~> 2.3.1'
 
-gem 'sass-rails', '~> 4.0.3'
+gem 'sass-rails', '~> 5.0.3'
 gem 'uglifier', '>= 1.3.0'
 
 gem 'generic_form_builder', '0.8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,12 +175,13 @@ GEM
       multi_json
       null_logger
       rest-client
-    sass (3.2.19)
-    sass-rails (4.0.3)
+    sass (3.4.14)
+    sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
-      sass (~> 3.2.0)
-      sprockets (~> 2.8, <= 2.11.0)
-      sprockets-rails (~> 2.0)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (~> 1.1)
     sprockets (2.11.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -229,6 +230,6 @@ DEPENDENCIES
   rspec-core (= 2.14.8)
   rspec-rails
   rummageable (= 1.2.0)
-  sass-rails (~> 4.0.3)
+  sass-rails (~> 5.0.3)
   uglifier (>= 1.3.0)
   unicorn


### PR DESCRIPTION
* Avoid problems with sass 3.2.19 and bootstrap-sass 3.3.5
(https://github.com/alphagov/govuk_admin_template/issues/70)
* Update to the latest version of sass, 3.4 so that the bootstrap sass
compiles correctly and the glyphicons load