### PR TITLE
Rake tasks to import CSV files and sync with Rummager

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,19 @@ database.yml.
 ## Bulk load to rummager
 
 In normal production use, whenever a modification is made in search-admin, any necessary corresponding updates are sent
-to rummager.  However, if you need to load from scratch, or if you think an update has gone astray, you can create a
-dump of data that rummager should have, and the load it in to rummager, using:
+to rummager.  However, if you need to load from scratch, or if you think an update has gone astray, you can bulk load data from the local database.
 
-    `bundle exec ruby bin/export_best_bets_for_elasticsearch > ~/metasearch.dump`
-    `cd /var/apps/rummager`  # Or wherever rummager is installed
-    `bundle exec ruby bin/bulk_load metasearch < ~/metasearch.dump`
+### Best bets
+
+Create a dump of data that rummager should have, and the load it in to rummager, using:
+
+    bundle exec ruby bin/export_best_bets_for_elasticsearch > ~/metasearch.dump
+    cd /var/apps/rummager  # Or wherever rummager is installed
+    bundle exec ruby bin/bulk_load metasearch < ~/metasearch.dump
+
+### Recommended links
+
+Run `bundle exec rake sync:recommended-links`
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,26 @@ The database.yml for this project is checked into source control so
 you'll need a local user with credentials that match those in
 database.yml.
 
-    `mysql> grant all on `search_admin\_%`.* to search_admin@localhost identified by 'search_admin';`
-
+    mysql> grant all on `search_admin\_%`.* to search_admin@localhost identified by 'search_admin';
 
 ### Running the test suite
 
 `bundle exec rake`
+
+## Import CSV files
+
+You can run `bundle exec rake csv:import filename=links.csv` to import all recommended links in the
+`links.csv` file into the search-admin database. You should then run the bulk load to Rummager as
+explained below.
+
+The format of the input CSV file is:
+
+* title: The title of the link
+* link: The URL of the link
+* description: A description of the link
+* keywords: A comma-separated (and therefore quoted) list of keywords
+
+The first line is considered to be a header and is therefore ignored.
 
 ## Bulk load to rummager
 

--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -15,7 +15,7 @@ class RecommendedLinksController < ApplicationController
   def create
     @recommended_link = RecommendedLink.new(create_recommended_link_params)
     if @recommended_link.save
-      rummager_add_link(@recommended_link)
+      RummagerLinkSynchronize.put(@recommended_link)
 
       redirect_to recommended_link_path(@recommended_link), notice: "Your recommended link was created successfully"
     else
@@ -37,7 +37,7 @@ class RecommendedLinksController < ApplicationController
     @recommended_link = find_recommended_link
 
     if @recommended_link.update_attributes(update_recommended_link_params)
-      rummager_add_link(@recommended_link)
+      RummagerLinkSynchronize.put(@recommended_link)
 
       redirect_to recommended_link_path(@recommended_link), notice: "Your recommended link was updated successfully"
     else
@@ -50,7 +50,7 @@ class RecommendedLinksController < ApplicationController
     recommended_link = find_recommended_link
 
     if recommended_link.destroy
-      rummager_delete_link(recommended_link)
+      RummagerLinkSynchronize.delete(recommended_link)
 
       redirect_to recommended_links_path, notice: "Your recommended link was deleted successfully"
     else
@@ -80,18 +80,5 @@ private
     if recommended_link.errors.include?(:recommended_link)
       RecommendedLink.where(link: recommended_link.link).first
     end
-  end
-
-  def rummager_add_link(recommended_link)
-    es_doc = ElasticSearchRecommendedLink.new(recommended_link)
-    rummager_index.add_document("edition", es_doc.id, es_doc.details)
-  end
-
-  def rummager_delete_link(recommended_link)
-    rummager_index.delete_document("edition", recommended_link.link)
-  end
-
-  def rummager_index
-    SearchAdmin.services(:rummager_index_mainstream)
   end
 end

--- a/app/models/elastic_search_recommended_link.rb
+++ b/app/models/elastic_search_recommended_link.rb
@@ -1,5 +1,5 @@
 class ElasticSearchRecommendedLink
-  delegate :format, to: :recommended_link
+  delegate :format, :link, :title, :description, to: :recommended_link
 
   def initialize(recommended_link)
     @recommended_link = recommended_link
@@ -23,11 +23,11 @@ class ElasticSearchRecommendedLink
 
   def details
     {
-      title: @recommended_link.title,
-      link: @recommended_link.link,
-      description: @recommended_link.description,
+      title: title,
+      link: link,
+      description: description,
       format: format,
-      indexable_content: @recommended_link.keywords
+      indexable_content: indexable_content
     }
   end
 
@@ -35,17 +35,11 @@ class ElasticSearchRecommendedLink
     link
   end
 
-  def format
-    if URI(@recommended_link.link).host.downcase == "www.gov.uk"
-      'inside-government-link'
-    else
-      'recommended-link'
-    end
+  def indexable_content
+    recommended_link.keywords
   end
 
 private
 
-  def link
-    @recommended_link.link
-  end
+  attr_reader :recommended_link
 end

--- a/app/models/recommended_link.rb
+++ b/app/models/recommended_link.rb
@@ -3,7 +3,12 @@ class RecommendedLink < ActiveRecord::Base
   validates :link, uniqueness: true
 
   def format
-    if URI(link).host.downcase == "www.gov.uk"
+    uri = URI(link)
+    if uri.scheme.nil?
+      uri = URI("https://" + link)
+    end
+
+    if uri.host.downcase == "www.gov.uk"
       'inside-government-link'
     else
       'recommended-link'

--- a/app/services/rummager_link_synchronize.rb
+++ b/app/services/rummager_link_synchronize.rb
@@ -1,27 +1,14 @@
-class RummagerLinkSynchronize
-  def initialize(recommended_link)
-    @recommended_link = recommended_link
-    @client = SearchAdmin.services(:rummager_index_mainstream)
-  end
-
-  def put
+module RummagerLinkSynchronize
+  def self.put(recommended_link, client: self.client)
     es_doc = ElasticSearchRecommendedLink.new(recommended_link)
     client.add_document("edition", es_doc.id, es_doc.details)
   end
 
-  def delete
+  def self.delete(recommended_link, client: self.client)
     client.delete_document("edition", recommended_link.link)
   end
 
-  def self.put(recommended_link)
-    self.new(recommended_link).put
+  def self.client
+    SearchAdmin.services(:rummager_index_mainstream)
   end
-
-  def self.delete(recommended_link)
-    self.new(recommended_link).delete
-  end
-
-private
-
-  attr_reader :client, :recommended_link
 end

--- a/app/services/rummager_link_synchronize.rb
+++ b/app/services/rummager_link_synchronize.rb
@@ -1,0 +1,27 @@
+class RummagerLinkSynchronize
+  def initialize(recommended_link)
+    @recommended_link = recommended_link
+    @client = SearchAdmin.services(:rummager_index_mainstream)
+  end
+
+  def put
+    es_doc = ElasticSearchRecommendedLink.new(recommended_link)
+    client.add_document("edition", es_doc.id, es_doc.details)
+  end
+
+  def delete
+    client.delete_document("edition", recommended_link.link)
+  end
+
+  def self.put(recommended_link)
+    self.new(recommended_link).put
+  end
+
+  def self.delete(recommended_link)
+    self.new(recommended_link).delete
+  end
+
+private
+
+  attr_reader :client, :recommended_link
+end

--- a/lib/tasks/csv-import.rake
+++ b/lib/tasks/csv-import.rake
@@ -1,0 +1,34 @@
+require 'csv'
+
+namespace "csv" do
+  desc "Import a CSV file with recommended links into the search-admin database"
+  task "import" => :environment do
+    filename = ENV["filename"]
+    links = []
+
+    fail "The file #{filename} does not exist." unless File.exist?(filename)
+
+    CSV.foreach(filename, encoding: "UTF-8", headers: true) do |row|
+      next if row.empty?
+
+      puts "Creating recommended link for #{row[0]}"
+      link = RecommendedLink.new(
+        title: row[0],
+        link: row[1],
+        description: row[2],
+        keywords: row[3]
+      )
+
+      if link.valid?
+        links.push link
+      else
+        fail "Error(s) on line #{$.} of the CSV file: #{link.errors.messages}"
+      end
+    end
+
+    puts "Saving all recommended links to the database"
+    RecommendedLink.transaction do
+      links.each(&:save!)
+    end
+  end
+end

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -1,0 +1,10 @@
+namespace "sync" do
+  desc "Ensure all recommended links in the db are present in rummager"
+  task "recommended-links" => :environment do
+    puts "Sending recommended links to rummager..."
+    RecommendedLink.all.each do |link|
+      puts "#{link.link}"
+      RummagerLinkSync.put(link)
+    end
+  end
+end

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -4,7 +4,7 @@ namespace "sync" do
     puts "Sending recommended links to rummager..."
     RecommendedLink.all.each do |link|
       puts "#{link.link}"
-      RummagerLinkSync.put(link)
+      RummagerLinkSynchronize.put(link)
     end
   end
 end

--- a/spec/models/recommended_link_spec.rb
+++ b/spec/models/recommended_link_spec.rb
@@ -24,6 +24,14 @@ describe RecommendedLink do
     )
     expect(recommended_link.format).to eq "recommended-link"
   end
+
+  it "uses recommended-link format if it is external and has no scheme" do
+    recommended_link = create(
+      :recommended_link,
+      link: "www.hello-world.com"
+    )
+    expect(recommended_link.format).to eq "recommended-link"
+  end
 end
 
 describe RecommendedLink, 'validations' do


### PR DESCRIPTION
Currently, recommended links are administered via the recommended-links scripts using CSV files. The first commit adds a rake task to search-admin (which provides a UI for administering recommended links as of https://github.com/alphagov/search-admin/pull/48) to import the existing CSV files and thereby sync the search-admin database with the content in Elasticsearch. The second commit adds a rake task to search-admin to send all recommended links to Rummager.

Trello: https://trello.com/c/WY4JGxKG/39-manage-external-recommended-links-in-search-admin

Follow-up to: https://github.com/alphagov/search-admin/pull/48
Depends on: https://github.com/alphagov/search-admin/pull/50

Paired with @MatMoore 