### PR TITLE
Remove configurable search-index

### DIFF
--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -66,7 +66,7 @@ private
 
   def create_recommended_link_params
     params.require(:recommended_link)
-      .permit(:link, :title, :description, :keywords, :search_index, :comment)
+      .permit(:link, :title, :description, :keywords, :comment)
       .merge(user_id: current_user.id)
   end
 
@@ -84,18 +84,14 @@ private
 
   def rummager_add_link(recommended_link)
     es_doc = ElasticSearchRecommendedLink.new(recommended_link)
-    rummager_index(recommended_link.search_index).add_document("edition", es_doc.id, es_doc.details)
+    rummager_index.add_document("edition", es_doc.id, es_doc.details)
   end
 
   def rummager_delete_link(recommended_link)
-    rummager_index(recommended_link.search_index).delete_document("edition", recommended_link.link)
+    rummager_index.delete_document("edition", recommended_link.link)
   end
 
-  def rummager_index(search_index)
-    if search_index == "government"
-      SearchAdmin.services(:rummager_index_government)
-    else
-      SearchAdmin.services(:rummager_index_mainstream)
-    end
+  def rummager_index
+    SearchAdmin.services(:rummager_index_mainstream)
   end
 end

--- a/app/models/recommended_link.rb
+++ b/app/models/recommended_link.rb
@@ -1,20 +1,16 @@
 class RecommendedLink < ActiveRecord::Base
-  SEARCH_INDEXES = %w(mainstream government)
-
-  validates :title, :link, :description, :keywords, :search_index, presence: true
-  validates :search_index, inclusion: { in: SEARCH_INDEXES }
+  validates :title, :link, :description, :keywords, presence: true
   validates :link, uniqueness: true
 
   def self.to_csv(*_args)
     CSV.generate do |csv|
-      csv << %w(title link description keywords index comment)
+      csv << %w(title link description keywords comment)
 
       all.each do |link|
         csv << [link.title,
                 link.link,
                 link.description,
                 link.keywords,
-                link.search_index,
                 link.comment.to_s
               ]
       end

--- a/app/views/recommended_links/_form.html.erb
+++ b/app/views/recommended_links/_form.html.erb
@@ -19,12 +19,6 @@
     <%= f.text_field :keywords, class: "form-control input-lg" %>
   </div>
 
-  <% if recommended_link.new_record? %>
-    <div class="form-group">
-      <%= f.select :search_index, RecommendedLink::SEARCH_INDEXES.map { |t| [t.humanize, t] }, class: "form-control input-lg" %>
-    </div>
-  <% end %>
-
   <div class="form-group">
     <%= f.text_area :comment, class: "form-control input-lg" %>
   </div>

--- a/config/initializers/services_and_listeners.rb
+++ b/config/initializers/services_and_listeners.rb
@@ -17,10 +17,6 @@ SearchAdmin.services(
   :rummager_index_mainstream,
   GdsApi::Rummager.new(Plek.current.find('rummager') + '/mainstream')
 )
-SearchAdmin.services(
-  :rummager_index_government,
-  GdsApi::Rummager.new(Plek.current.find('rummager') + '/government')
-)
 
 require 'gds_api/rummager'
 

--- a/db/migrate/20160815115453_add_recommended_links.rb
+++ b/db/migrate/20160815115453_add_recommended_links.rb
@@ -5,7 +5,6 @@ class AddRecommendedLinks < ActiveRecord::Migration
       t.string :link
       t.string :description
       t.string :keywords
-      t.string :search_index
       t.text :comment
       t.references :user
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,13 +31,12 @@ ActiveRecord::Schema.define(version: 20160818081220) do
   end
 
   create_table "recommended_links", force: :cascade do |t|
-    t.string  "title",        limit: 255
-    t.string  "link",         limit: 255
-    t.string  "description",  limit: 255
-    t.string  "keywords",     limit: 255
-    t.string  "search_index", limit: 255
-    t.text    "comment",      limit: 65535
-    t.integer "user_id",      limit: 4
+    t.string  "title",       limit: 255
+    t.string  "link",        limit: 255
+    t.string  "description", limit: 255
+    t.string  "keywords",    limit: 255
+    t.text    "comment",     limit: 65535
+    t.integer "user_id",     limit: 4
   end
 
   create_table "users", force: :cascade do |t|

--- a/features/step_definitions/recommended_links_steps.rb
+++ b/features/step_definitions/recommended_links_steps.rb
@@ -18,8 +18,7 @@ When(/^I create a new recommended link$/) do
     title: 'Tax online',
     link: 'https://www.tax.service.gov.uk/',
     description: 'File your self assessment online.',
-    keywords: 'tax, self assessment, hmrc',
-    search_index: 'mainstream'
+    keywords: 'tax, self assessment, hmrc'
   )
 end
 

--- a/features/support/recommended_links.rb
+++ b/features/support/recommended_links.rb
@@ -1,4 +1,4 @@
-def create_recommended_link(title: nil, link: nil, description: nil, keywords: nil, search_index: nil)
+def create_recommended_link(title: nil, link: nil, description: nil, keywords: nil)
   visit recommended_links_path
 
   click_on 'New recommended link'
@@ -7,7 +7,6 @@ def create_recommended_link(title: nil, link: nil, description: nil, keywords: n
   fill_in 'Title', with: title if title
   fill_in 'Description', with: description if description
   fill_in 'Keywords', with: keywords if keywords
-  select search_index.humanize, from: 'Search index' if search_index
 
   click_on 'Save'
 end
@@ -58,7 +57,7 @@ end
 def check_for_recommended_links_in_csv_format(recommended_links)
   headers, *rows = *CSV.parse(page.body)
 
-  expect(headers).to eq(%w(title link description keywords index comment))
+  expect(headers).to eq(%w(title link description keywords comment))
 
   recommended_links.each do |recommended_link|
     expect(rows).to include([
@@ -66,7 +65,6 @@ def check_for_recommended_links_in_csv_format(recommended_links)
       recommended_link.link,
       recommended_link.description,
       recommended_link.keywords,
-      recommended_link.search_index,
       ''
     ])
   end

--- a/features/support/rummager.rb
+++ b/features/support/rummager.rb
@@ -4,7 +4,4 @@ Before do
 
   rummager_index_mainstream = double(:rummager_index_mainstream, add_document: nil, delete_document: nil)
   SearchAdmin.services(:rummager_index_mainstream, rummager_index_mainstream)
-
-  rummager_index_government = double(:rummager_index_government, add_document: nil, delete_document: nil)
-  SearchAdmin.services(:rummager_index_government, rummager_index_government)
 end

--- a/spec/controllers/recommended_links_controller_spec.rb
+++ b/spec/controllers/recommended_links_controller_spec.rb
@@ -6,20 +6,19 @@ describe RecommendedLinksController do
       title: 'Tax',
       link: 'https://www.tax.service.gov.uk/',
       description: 'Self assessment',
-      keywords: 'self, assessment, tax',
-      search_index: 'mainstream'
+      keywords: 'self, assessment, tax'
     }
   end
 
   describe '#create' do
     context 'on failure' do
       it "alerts the user" do
-        post :create, recommended_link: recommended_link_params.merge(search_index: nil)
+        post :create, recommended_link: recommended_link_params.merge(title: nil)
         expect(flash[:alert]).to include('could not create')
       end
 
       it "renders the new action" do
-        post :create, recommended_link: recommended_link_params.merge(search_index: nil)
+        post :create, recommended_link: recommended_link_params.merge(title: nil)
         expect(response).to render_template('new')
       end
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -34,7 +34,6 @@ FactoryGirl.define do
     link "https://www.tax.service.gov.uk/"
     description "File your self assessment online."
     keywords "tax, self assessment, hmrc"
-    search_index "mainstream"
   end
 
   factory :user do

--- a/spec/models/elastic_search_recommended_link_spec.rb
+++ b/spec/models/elastic_search_recommended_link_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ElasticSearchRecommendedLink do
-  let(:recommended_link) { create(:recommended_link, title: 'Tax', link: 'https://www.tax.service.gov.uk/', description: 'Self assessment', keywords: 'self, assessment, tax', search_index: 'mainstream') }
+  let(:recommended_link) { create(:recommended_link, title: 'Tax', link: 'https://www.tax.service.gov.uk/', description: 'Self assessment', keywords: 'self, assessment, tax') }
 
   it "builds an elasticsearch header from the provided recommended link" do
     es_recommended_link = ElasticSearchRecommendedLink.new(recommended_link)

--- a/spec/models/recommended_link_spec.rb
+++ b/spec/models/recommended_link_spec.rb
@@ -8,29 +8,11 @@ describe RecommendedLink, 'validations' do
   end
 
   it "is invalid with a duplicate link" do
-    create(:recommended_link, title: 'Tax', link: 'https://www.tax.service.gov.uk/', description: 'Self assessment', keywords: 'self, assessment, tax', search_index: 'mainstream')
+    create(:recommended_link, title: 'Tax', link: 'https://www.tax.service.gov.uk/', description: 'Self assessment', keywords: 'self, assessment, tax')
 
-    recommended_link = new_recommended_link_with(title: 'Tax', link: 'https://www.tax.service.gov.uk/', description: 'Self assessment', keywords: 'self, assessment, tax', search_index: 'mainstream')
+    recommended_link = new_recommended_link_with(title: 'Tax', link: 'https://www.tax.service.gov.uk/', description: 'Self assessment', keywords: 'self, assessment, tax')
 
     expect(recommended_link).to_not be_valid
-  end
-
-  it 'validates inclusion of search_index in RecommendedLink::SEARCH_INDEXES' do
-    attributes = attributes_for(:recommended_link, search_index: 'not like the others')
-
-    expect(new_recommended_link_with(attributes)).not_to be_valid
-  end
-
-  it "is valid with a search_index of 'mainstream'" do
-    attributes = attributes_for(:recommended_link, search_index: 'mainstream')
-
-    expect(new_recommended_link_with(attributes)).to be_valid
-  end
-
-  it "is valid with a search_index of 'government'" do
-    attributes = attributes_for(:recommended_link, search_index: 'government')
-
-    expect(new_recommended_link_with(attributes)).to be_valid
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,6 @@ RSpec.configure do |config|
   config.before(:each) do
     SearchAdmin.services(:rummager_index_metasearch, double(:rummager_index_metasearch, add_document: nil, delete_document: nil))
     SearchAdmin.services(:rummager_index_mainstream, double(:rummager_index_mainstream, add_document: nil, delete_document: nil))
-    SearchAdmin.services(:rummager_index_government, double(:rummager_index_government, add_document: nil, delete_document: nil))
   end
 
   config.before(:each, type: 'controller') do


### PR DESCRIPTION
search-admin currently allows users to choose between the `mainstream` and `government` search indexes for saving recommended links. Based on comments on https://github.com/alphagov/search-admin/pull/48 and a conversation with Tara Stockford, we’ve decided to send all recommended links to the `mainstream` index by default. This commit removes the option for the user to choose the index.

The migration from the previous commit has been edited (rather than creating a new migration to reverse the changes) since that commit has not yet been deployed.

Trello: https://trello.com/c/WY4JGxKG/39-manage-external-recommended-links-in-search-admin

Follow-up to: https://github.com/alphagov/search-admin/pull/48

Before:
![8f32a592-6491-11e6-946f-7d0bc9586ee7](https://cloud.githubusercontent.com/assets/444232/17777965/5f8b5798-655a-11e6-9683-8876217d5331.png)

After:
![screen shot 2016-08-18 at 15 42 10](https://cloud.githubusercontent.com/assets/444232/17777974/64ec6d12-655a-11e6-900a-842e70e2ac0e.png)
