### PR TITLE
Use inside-government-link type for internal links

### DIFF
--- a/app/models/elastic_search_recommended_link.rb
+++ b/app/models/elastic_search_recommended_link.rb
@@ -1,4 +1,6 @@
 class ElasticSearchRecommendedLink
+  delegate :format, to: :recommended_link
+
   def initialize(recommended_link)
     @recommended_link = recommended_link
   end
@@ -7,7 +9,7 @@ class ElasticSearchRecommendedLink
     {
       index: {
         _id: id,
-        _type: type
+        _type: format
       }
     }
   end
@@ -24,7 +26,7 @@ class ElasticSearchRecommendedLink
       title: @recommended_link.title,
       link: @recommended_link.link,
       description: @recommended_link.description,
-      format: type,
+      format: format,
       indexable_content: @recommended_link.keywords
     }
   end
@@ -33,15 +35,15 @@ class ElasticSearchRecommendedLink
     link
   end
 
-private
-
-  def type
-    if @recommended_link.link.start_with?("https://www.gov.uk")
+  def format
+    if URI(@recommended_link.link).host.downcase == "www.gov.uk"
       'inside-government-link'
     else
       'recommended-link'
     end
   end
+
+private
 
   def link
     @recommended_link.link

--- a/app/models/elastic_search_recommended_link.rb
+++ b/app/models/elastic_search_recommended_link.rb
@@ -36,7 +36,11 @@ class ElasticSearchRecommendedLink
 private
 
   def type
-    'recommended-link'
+    if @recommended_link.link.start_with?("https://www.gov.uk")
+      'inside-government-link'
+    else
+      'recommended-link'
+    end
   end
 
   def link

--- a/app/models/recommended_link.rb
+++ b/app/models/recommended_link.rb
@@ -5,6 +5,14 @@ class RecommendedLink < ActiveRecord::Base
   validates :search_index, inclusion: { in: SEARCH_INDEXES }
   validates :link, uniqueness: true
 
+  def format
+    if URI(link).host.downcase == "www.gov.uk"
+      'inside-government-link'
+    else
+      'recommended-link'
+    end
+  end
+
   def self.to_csv(*_args)
     CSV.generate do |csv|
       csv << %w(title link description keywords index comment)

--- a/features/step_definitions/recommended_links_steps.rb
+++ b/features/step_definitions/recommended_links_steps.rb
@@ -11,6 +11,7 @@ end
 Given(/^a variety of recommended links exist$/) do
   create(:recommended_link, title: "Jobs", link: "https://www.gov.uk/jobsearch")
   create(:recommended_link, title: "Visas", link: "https://www.gov.uk/apply-uk-visa")
+  create(:recommended_link, title: "Blogs", link: "https://www.blog.gov.uk/")
 end
 
 When(/^I create a new recommended link$/) do

--- a/features/support/recommended_links.rb
+++ b/features/support/recommended_links.rb
@@ -91,7 +91,7 @@ def confirm_recommended_links_elasticsearch_format(dump, recommended_links)
     es_doc_header = {
       'index' => {
         '_id' => "#{recommended_link.link}",
-        '_type' => type(recommended_link)
+        '_type' => recommended_link.format
       }
     }
 
@@ -105,7 +105,7 @@ def build_doc_from_recommended_link(recommended_link, include_es_data: false)
     title: recommended_link.title,
     link: recommended_link.link,
     description: recommended_link.description,
-    format: type(recommended_link),
+    format: recommended_link.format,
     indexable_content: recommended_link.keywords
   }
 
@@ -116,15 +116,5 @@ def build_doc_from_recommended_link(recommended_link, include_es_data: false)
     }
   else
     details
-  end
-end
-
-private
-
-def type(recommended_link)
-  if recommended_link.link.start_with?("https://www.gov.uk")
-    'inside-government-link'
-  else
-    'recommended-link'
   end
 end

--- a/features/support/recommended_links.rb
+++ b/features/support/recommended_links.rb
@@ -91,7 +91,7 @@ def confirm_recommended_links_elasticsearch_format(dump, recommended_links)
     es_doc_header = {
       'index' => {
         '_id' => "#{recommended_link.link}",
-        '_type' => 'recommended-link'
+        '_type' => type(recommended_link)
       }
     }
 
@@ -105,7 +105,7 @@ def build_doc_from_recommended_link(recommended_link, include_es_data: false)
     title: recommended_link.title,
     link: recommended_link.link,
     description: recommended_link.description,
-    format: "recommended-link",
+    format: type(recommended_link),
     indexable_content: recommended_link.keywords
   }
 
@@ -116,5 +116,15 @@ def build_doc_from_recommended_link(recommended_link, include_es_data: false)
     }
   else
     details
+  end
+end
+
+private
+
+def type(recommended_link)
+  if recommended_link.link.start_with?("https://www.gov.uk")
+    'inside-government-link'
+  else
+    'recommended-link'
   end
 end

--- a/spec/models/recommended_link_spec.rb
+++ b/spec/models/recommended_link_spec.rb
@@ -1,5 +1,31 @@
 require 'spec_helper'
 
+describe RecommendedLink do
+  it "uses recommended-link format if it is external to gov.uk" do
+    recommended_link = create(
+      :recommended_link,
+      link: "https://www.google.com"
+    )
+    expect(recommended_link.format).to eq "recommended-link"
+  end
+
+  it "uses inside-government-link format if it is internal to gov.uk" do
+    recommended_link = create(
+      :recommended_link,
+      link: "https://www.gov.uk/bank-holidays"
+    )
+    expect(recommended_link.format).to eq "inside-government-link"
+  end
+
+  it "uses recommended-link format if it is external to gov.uk but has a gov.uk domain" do
+    recommended_link = create(
+      :recommended_link,
+      link: "https://www.free-ice-cream.gov.uk"
+    )
+    expect(recommended_link.format).to eq "recommended-link"
+  end
+end
+
 describe RecommendedLink, 'validations' do
   it 'is invalid without a title attribute' do
     attributes = attributes_for(:recommended_link, title: nil)


### PR DESCRIPTION
search-admin uses the `recommended-link` type when sending recommended links to Rummager. However, internal links (those starting with www.gov.uk) should instead use the type `inside-government-link`. This commit changes search-admin to support this type.

Trello: https://trello.com/c/WY4JGxKG/39-manage-external-recommended-links-in-search-admin

Follow-up to: https://github.com/alphagov/search-admin/pull/48