### PR TITLE
Add URL validation when adding recommended links

### DIFF
--- a/app/models/recommended_link.rb
+++ b/app/models/recommended_link.rb
@@ -1,6 +1,6 @@
 class RecommendedLink < ActiveRecord::Base
   validates :title, :link, :description, :keywords, presence: true
-  validates :link, uniqueness: true
+  validates :link, uniqueness: true, url: true
 
   def format
     uri = URI(link)

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -1,0 +1,14 @@
+require 'uri'
+
+class UrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    valid = begin
+      URI.parse(value).is_a?(URI::HTTP)
+    rescue URI::InvalidURIError
+      false
+    end
+    unless valid
+      record.errors[attribute] << (options[:message] || "is an invalid URL")
+    end
+  end
+end

--- a/spec/models/recommended_link_spec.rb
+++ b/spec/models/recommended_link_spec.rb
@@ -24,19 +24,17 @@ describe RecommendedLink do
     )
     expect(recommended_link.format).to eq "recommended-link"
   end
-
-  it "uses recommended-link format if it is external and has no scheme" do
-    recommended_link = create(
-      :recommended_link,
-      link: "www.hello-world.com"
-    )
-    expect(recommended_link.format).to eq "recommended-link"
-  end
 end
 
 describe RecommendedLink, 'validations' do
   it 'is invalid without a title attribute' do
     attributes = attributes_for(:recommended_link, title: nil)
+
+    expect(new_recommended_link_with(attributes)).not_to be_valid
+  end
+
+  it 'is invalid with an incomplete link' do
+    attributes = attributes_for(:recommended_link, link: 'www.hello-world.com')
 
     expect(new_recommended_link_with(attributes)).not_to be_valid
   end


### PR DESCRIPTION
When creating a recommended link, search-admin currently accepts any string as a valid URL without validation. This means that invalid or relative URLs can be added.

This commit adds model-level validation to check that a submitted URL is a valid absolute URL with a scheme of either HTTP or HTTPS. Invalid URLs are rejected with an error message.

Trello: https://trello.com/c/73lm8u2X/97-validate-search-admin-recommended-link-urls

Example of UI when an invalid URL is entered:

![screen shot 2016-08-30 at 13 11 07](https://cloud.githubusercontent.com/assets/444232/18088666/c85b57d4-6eb3-11e6-9d85-8249e2397741.png)
