### PR TITLE
Upgrade sass-rails to address deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 
 gem 'govuk_admin_template', '~> 4.1.1'
 
-gem 'sass-rails', '~> 5.0.3'
+gem 'sass-rails', '~> 5.0.6'
 gem 'uglifier', '~> 2.7.2'
 
 gem 'generic_form_builder', '~> 0.8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
     ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
-    sass-rails (5.0.5)
+    sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
@@ -307,7 +307,7 @@ DEPENDENCIES
   quiet_assets
   rails (= 4.2.7.1)
   rspec-rails (~> 3.3.3)
-  sass-rails (~> 5.0.3)
+  sass-rails (~> 5.0.6)
   uglifier (~> 2.7.2)
   unicorn (~> 4.9.0)
   webmock (~> 1.21.0)


### PR DESCRIPTION
Same change as https://github.com/alphagov/policy-publisher/pull/149

After upgrading rails we got this warning:

```
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then
use `register_compressor` or `register_transformer`.
```