### PR TITLE
URL encode ElasticSearch bet ID

### DIFF
--- a/app/listeners/rummager_notifier.rb
+++ b/app/listeners/rummager_notifier.rb
@@ -13,7 +13,7 @@ class RummagerNotifier
       SearchAdmin.services(:rummager_index_metasearch).add_document(es_doc.type, es_doc.id, es_doc.body)
     else
       es_doc_id = ElasticSearchBetIDGenerator.generate(query_string, match_type)
-      SearchAdmin.services(:rummager_index_metasearch).delete_document("best_bet", es_doc_id)
+      SearchAdmin.services(:rummager_index_metasearch).delete_document("best_bet", CGI.escape(es_doc_id))
     end
   end
 end

--- a/features/step_definitions/best_bet_steps.rb
+++ b/features/step_definitions/best_bet_steps.rb
@@ -1,5 +1,5 @@
 When(/^I create a best bet$/) do
-  create_query(query: 'jobs', match_type: 'exact', links: [['/jobsearch', true, 1, 'a comment']])
+  create_query(query: 'some jobs', match_type: 'exact', links: [['/jobsearch', true, 1, 'a comment']])
 end
 
 When(/^I create a worst bet for a query$/) do
@@ -12,7 +12,7 @@ end
 
 Then(/^the query should be listed on the index page$/) do
   check_for_query_on_index_page(
-    query: 'jobs',
+    query: 'some jobs',
     match_type: 'exact'
   )
 end
@@ -24,7 +24,7 @@ Then(/^the best bet should be listed on the query page$/) do
     link: '/jobsearch',
     match_type: 'exact',
     position: 1,
-    query: 'jobs',
+    query: 'some jobs',
   )
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,8 +28,11 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 
   config.before(:each) do
-    SearchAdmin.services(:rummager_index_metasearch, double(:rummager_index_metasearch, add_document: nil, delete_document: nil))
-    SearchAdmin.services(:rummager_index_mainstream, double(:rummager_index_mainstream, add_document: nil, delete_document: nil))
+    # rummager URLs are of the form: http://rummager.dev.gov.uk/mainstream/document/http://test.dev.gov.uk
+    # The part after /document/ is optional depending on the request type
+    rummager_url_regex = %r{#{Plek.find('rummager')}/.+/.+(/.*)?}
+    stub_request(:post, rummager_url_regex)
+    stub_request(:delete, rummager_url_regex)
   end
 
   config.before(:each, type: 'controller') do


### PR DESCRIPTION
When sending a notification to rummager to delete a best/worst bet, search-admin does not correctly encode the bet ID in the URL. Therefore, when the ID includes spaces, the resulting URL fails a validation test.

This commit URL-encodes the ID when it is used to send a delete notification to rummager.

Trello: https://trello.com/c/yR6nHzQA/103-fix-uri-invalidurierror-errors-for-search-admin