### PR TITLE
Allow edit of recommended links

### DIFF
--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -35,8 +35,15 @@ class RecommendedLinksController < ApplicationController
 
   def update
     @recommended_link = find_recommended_link
+    old_recommended_link = RecommendedLink.new(link: @recommended_link.link)
 
     if @recommended_link.update_attributes(update_recommended_link_params)
+
+      # Delete the record from rummager if the link has changed
+      if @recommended_link.link != old_recommended_link.link
+        RummagerLinkSynchronize.delete(old_recommended_link)
+      end
+
       RummagerLinkSynchronize.put(@recommended_link)
 
       redirect_to recommended_link_path(@recommended_link), notice: "Your recommended link was updated successfully"
@@ -72,7 +79,7 @@ private
 
   def update_recommended_link_params
     params.require(:recommended_link)
-      .permit(:title, :description, :keywords, :comment)
+      .permit(:link, :title, :description, :keywords, :comment)
       .merge(user_id: current_user.id)
   end
 

--- a/app/views/recommended_links/_form.html.erb
+++ b/app/views/recommended_links/_form.html.erb
@@ -1,10 +1,6 @@
 <%= form_for(recommended_link) do |f| %>
   <div class="form-group">
-    <% if recommended_link.new_record? %>
-      <%= f.text_field :link, class: "form-control input-lg" %>
-    <% else %>
-      <%= f.text_field :link, class: "form-control input-lg", disabled: true %>
-    <% end %>
+    <%= f.text_field :link, class: "form-control input-lg" %>
   </div>
 
   <div class="form-group">

--- a/spec/controllers/recommended_links_controller_spec.rb
+++ b/spec/controllers/recommended_links_controller_spec.rb
@@ -71,6 +71,12 @@ describe RecommendedLinksController do
         update_recommended_link
         expect(response).to redirect_to(recommended_link_path(RecommendedLink.last))
       end
+
+      it 'notifies rummager of the changes' do
+        expect(RummagerLinkSynchronize).to receive(:put).with(recommended_link)
+
+        update_recommended_link(title: 'A new title')
+      end
     end
   end
 


### PR DESCRIPTION
This change allows us to change the link of a `RecommendedLink` object. In doing
so, we delete the old record from Rummager in case the link has changed. We also
add the new information to Rummager so all searches are up-to-date.

Trello: https://trello.com/c/RZP5P8ip/220-edit-url-of-recommended-links-external-links-in-search-admin

Thanks @klssmith for pairing with me on this :)