### PR TITLE
Validate maximum value for bet position

### DIFF
--- a/app/models/bet.rb
+++ b/app/models/bet.rb
@@ -10,6 +10,7 @@ class Bet < ActiveRecord::Base
   validates :position, numericality: {
                          allow_nil: false,
                          greater_than: 0,
+                         less_than: 2147483647, # Maximum value for integer
                          only_integer: true
                        }, if: :is_best?
 


### PR DESCRIPTION
This commit adds validation on the bet position to make sure its value is not greater than the maximum possible value for a 4-byte integer.

Trello: https://trello.com/c/s5ybhaot/390-fix-search-admin-crash