### PR TITLE
Rename recommended links to external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Search admin
 
-The `search-admin` application manages search "best bets" and "recommended links" along with other search and browse data.
+The `search-admin` application manages search "best bets" and "external links" along with other search and browse data.
 
 ## Live example
 
@@ -8,11 +8,11 @@ The `search-admin` application manages search "best bets" and "recommended links
 
 ## Technical documentation
 
-This is a Ruby on Rails application that manages search "best bets" and "recommended links" along with other search and browse data. It is behind the signon authentication system and doesn't have a public API.
+This is a Ruby on Rails application that manages search "best bets" and "external links" along with other search and browse data. It is behind the signon authentication system and doesn't have a public API.
 
 ### Dependencies
 
-- [alphagov/rummager](https://github.com/alphagov/rummager) - search-admin sends updates to rummager when best bets and recommended links are edited
+- [alphagov/rummager](https://github.com/alphagov/rummager) - search-admin sends updates to rummager when best bets and external links are edited
 
 ### Running the application
 
@@ -32,9 +32,9 @@ database.yml.
 
 `bundle exec rake`
 
-### Recommended links
+### External links
 
-Run `bundle exec rake publish_recommended_links` to send all recommended links to Rummager.
+Run `bundle exec rake publish_external_links` to send all external links to rummager.
 
 ## Licence
 

--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -17,9 +17,9 @@ class RecommendedLinksController < ApplicationController
     if @recommended_link.save
       RummagerLinkSynchronize.put(@recommended_link)
 
-      redirect_to recommended_link_path(@recommended_link), notice: "Your recommended link was created successfully"
+      redirect_to recommended_link_path(@recommended_link), notice: "Your external link was created successfully"
     else
-      flash[:alert] = "We could not create your recommended link"
+      flash[:alert] = "We could not create your external link"
       render :new
     end
   end
@@ -46,9 +46,9 @@ class RecommendedLinksController < ApplicationController
 
       RummagerLinkSynchronize.put(@recommended_link)
 
-      redirect_to recommended_link_path(@recommended_link), notice: "Your recommended link was updated successfully"
+      redirect_to recommended_link_path(@recommended_link), notice: "Your external link was updated successfully"
     else
-      flash[:alert] = "We could not update your recommended link"
+      flash[:alert] = "We could not update your external link"
       render :edit
     end
   end
@@ -59,9 +59,9 @@ class RecommendedLinksController < ApplicationController
     if recommended_link.destroy
       RummagerLinkSynchronize.delete(recommended_link)
 
-      redirect_to recommended_links_path, notice: "Your recommended link was deleted successfully"
+      redirect_to recommended_links_path, notice: "Your external link was deleted successfully"
     else
-      redirect_to recommended_link_path(recommended_link), alert: "We could not delete your recommended link"
+      redirect_to recommended_link_path(recommended_link), alert: "We could not delete your external link"
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
   </li>
 
   <li class='<%= controller_name == "recommended_links" ? "active" : nil %>'>
-    <%= link_to 'Recommended links', recommended_links_path %>
+    <%= link_to 'External links', recommended_links_path %>
   </li>
 
   <li class='<%= controller_name == "results" ? "active" : nil %>'>

--- a/app/views/recommended_links/edit.html.erb
+++ b/app/views/recommended_links/edit.html.erb
@@ -1,5 +1,5 @@
 <ol class="breadcrumb">
-  <li><%= link_to 'Recommended links', recommended_links_path %></li>
+  <li><%= link_to 'External links', recommended_links_path %></li>
   <li><%= link_to @recommended_link.title, recommended_link_path(@recommended_link) %></li>
   <li class="active">Edit</li>
 </ol>

--- a/app/views/recommended_links/index.html.erb
+++ b/app/views/recommended_links/index.html.erb
@@ -1,11 +1,11 @@
 <ol class="breadcrumb">
-  <li class="active">Recommended links</li>
+  <li class="active">External links</li>
 </ol>
 
-<%= page_title 'Recommended links' %>
+<%= page_title 'External links' %>
 
 <div class="actions">
-  <%= link_to icon(:plus) + ' New recommended link', new_recommended_link_path, class: 'btn btn-primary'%>
+  <%= link_to icon(:plus) + ' New external link', new_recommended_link_path, class: 'btn btn-primary'%>
   <%= link_to icon(:download) + ' Download CSV', recommended_links_path(format: 'csv'), class: 'btn btn-default' %>
 </div>
 

--- a/app/views/recommended_links/new.html.erb
+++ b/app/views/recommended_links/new.html.erb
@@ -1,8 +1,8 @@
 <ol class="breadcrumb">
-  <li><%= link_to 'Recommended links', recommended_links_path %></li>
-  <li class="active">New recommended link</li>
+  <li><%= link_to 'External links', recommended_links_path %></li>
+  <li class="active">New external link</li>
 </ol>
 
-<%= page_title 'New recommended link' %>
+<%= page_title 'New external link' %>
 
 <%= render 'form', recommended_link: @recommended_link %>

--- a/app/views/recommended_links/show.html.erb
+++ b/app/views/recommended_links/show.html.erb
@@ -1,13 +1,13 @@
 <ol class="breadcrumb">
-  <li><%= link_to 'Recommended links', recommended_links_path %></li>
+  <li><%= link_to 'External links', recommended_links_path %></li>
   <li class="active"><%= @recommended_link.title %></li>
 </ol>
 
 <%= page_title @recommended_link.title %>
 
 <div class="actions">
-  <%= link_to "Edit recommended link", edit_recommended_link_path(@recommended_link), class: 'btn btn-default' %>
-  <%= delete_button "Delete recommended link", recommended_link_path(@recommended_link) %>
+  <%= link_to "Edit external link", edit_recommended_link_path(@recommended_link), class: 'btn btn-default' %>
+  <%= delete_button "Delete external link", recommended_link_path(@recommended_link) %>
 </div>
 
 <h3>Search results</h3>
@@ -15,7 +15,7 @@
 
 <div class='callout callout-info add-bottom-margin'>
   <div class="callout-title">
-    There is a slight delay between the updating of a recommended link and the
+    There is a slight delay between the updating of an external link and the
     indexing by the search engine. If you're seeing unexpected results,
     <a href='' id='search-results-refresh'>try refreshing these results</a>.
   </div>

--- a/features/navigation.feature
+++ b/features/navigation.feature
@@ -7,6 +7,6 @@ Feature: Navigating across pages
     Given I am viewing a specific query
     Then I can click a link to navigate to the index of queries
 
-    Scenario: Navigating from a specific recommended link back to the index of recommended links
-      Given I am viewing a specific recommended link
-      Then I can click a link to navigate to the index of recommended links
+    Scenario: Navigating from a specific external link back to the index of external links
+      Given I am viewing a specific external link
+      Then I can click a link to navigate to the index of external links

--- a/features/recommended_links.feature
+++ b/features/recommended_links.feature
@@ -1,23 +1,23 @@
-Feature: Recommended links
+Feature: External links
   As as a search admin
-  I want to be able to create recommended links
+  I want to be able to create external links
   So that better results are provided to the users
 
-  Scenario: Viewing a recommended link
-    When I create a new recommended link
-    And I visit the recommended link
-    Then I should see the recommended links search results on the page
+  Scenario: Viewing an external link
+    When I create a new external link
+    And I visit the external link
+    Then I should see the external links search results on the page
 
-  Scenario: Creating a recommended link
-    When I create a new recommended link
-    Then the recommended link named "Tax online" should be listed on the recommended links index
+  Scenario: Creating an external link
+    When I create a new external link
+    Then the external link named "Tax online" should be listed on the external links index
 
-  Scenario: Editing a recommended link
-    Given a recommended link exists named "Tax online" with link "https://www.tax.service.gov.uk/"
-    When I edit the recommended link named "Tax online" with link "https://www.tax.service.gov.uk/" to be named "The new tax online"
-    Then the edited recommended link named "The new tax online" should be listed on the recommended links index
+  Scenario: Editing an external link
+    Given an external link exists named "Tax online" with link "https://www.tax.service.gov.uk/"
+    When I edit the external link named "Tax online" with link "https://www.tax.service.gov.uk/" to be named "The new tax online"
+    Then the edited external link named "The new tax online" should be listed on the external links index
 
-  Scenario: Deleting a recommended link
-    Given a recommended link exists named "Tax online" with link "https://www.tax.service.gov.uk/"
-    When I delete the recommended link named "Tax online" with link "https://www.tax.service.gov.uk/"
-    Then the recommended link named "Tax online" should not be listed on the recommended links index
+  Scenario: Deleting an external link
+    Given an external link exists named "Tax online" with link "https://www.tax.service.gov.uk/"
+    When I delete the external link named "Tax online" with link "https://www.tax.service.gov.uk/"
+    Then the external link named "Tax online" should not be listed on the external links index

--- a/features/recommended_links_csv.feature
+++ b/features/recommended_links_csv.feature
@@ -1,9 +1,9 @@
-Feature: Recommended links CSV
+Feature: External links CSV
   As a search admin
-  I want to be able to list all recommended links as a CSV
-  So that I can check for recommended links referring to dead URLs.
+  I want to be able to list all external links as a CSV
+  So that I can check for external links referring to dead URLs.
 
-  Scenario: There are some recommended links
-    Given there are some recommended links
-    When I view the recommended links CSV
-    Then I should see all recommended links listed in the CSV
+  Scenario: There are some external links
+    Given there are some external links
+    When I view the external links CSV
+    Then I should see all external links listed in the CSV

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -11,14 +11,14 @@ Then(/^I can click a link to navigate to the index of queries$/) do
   expect(current_path).to eq queries_path
 end
 
-Given(/^I am viewing a specific recommended link$/) do
+Given(/^I am viewing a specific external link$/) do
   recommended_link = create(:recommended_link)
   visit recommended_link_path(recommended_link)
 end
 
-Then(/^I can click a link to navigate to the index of recommended links$/) do
+Then(/^I can click a link to navigate to the index of external links$/) do
   within(".breadcrumb") do
-    click_link 'Recommended links'
+    click_link 'External links'
   end
 
   expect(current_path).to eq recommended_links_path

--- a/features/step_definitions/recommended_links_csv_steps.rb
+++ b/features/step_definitions/recommended_links_csv_steps.rb
@@ -1,9 +1,9 @@
-When(/^I view the recommended links CSV$/) do
+When(/^I view the external links CSV$/) do
   visit recommended_links_path
 
   click_on 'Download CSV'
 end
 
-Then(/^I should see all recommended links listed in the CSV$/) do
+Then(/^I should see all external links listed in the CSV$/) do
   check_for_recommended_links_in_csv_format(@recommended_links)
 end

--- a/features/step_definitions/recommended_links_steps.rb
+++ b/features/step_definitions/recommended_links_steps.rb
@@ -1,20 +1,20 @@
-Given(/^a recommended link exists named "(.*)" with link "(.*)"$/) do |title, link|
+Given(/^an external link exists named "(.*)" with link "(.*)"$/) do |title, link|
   @recommended_link = create(:recommended_link, title: title, link: link)
 end
 
-Given(/^there are some recommended links$/) do
+Given(/^there are some external links$/) do
   @recommended_links = (1..3).map { |n|
     create(:recommended_link, title: "Tax online #{n}", link: "https://www.tax.service.gov.uk/#{n}")
   }
 end
 
-Given(/^a variety of recommended links exist$/) do
+Given(/^a variety of external links exist$/) do
   create(:recommended_link, title: "Jobs", link: "https://www.gov.uk/jobsearch")
   create(:recommended_link, title: "Visas", link: "https://www.gov.uk/apply-uk-visa")
   create(:recommended_link, title: "Blogs", link: "https://www.blog.gov.uk/")
 end
 
-When(/^I create a new recommended link$/) do
+When(/^I create a new external link$/) do
   create_recommended_link(
     title: 'Tax online',
     link: 'https://www.tax.service.gov.uk/',
@@ -23,11 +23,11 @@ When(/^I create a new recommended link$/) do
   )
 end
 
-Then(/^the recommended link named "(.*)" should be listed on the recommended links index$/) do |title|
+Then(/^the external link named "(.*)" should be listed on the external links index$/) do |title|
   check_for_recommended_link_on_index_page(title: title)
 end
 
-When(/^I edit the recommended link named "(.*)" with link "(.*)" to be named "(.*)"$/) do |old_title, link, new_title|
+When(/^I edit the external link named "(.*)" with link "(.*)" to be named "(.*)"$/) do |old_title, link, new_title|
   edit_recommended_link(
     old_title: old_title,
     old_link: link,
@@ -35,23 +35,23 @@ When(/^I edit the recommended link named "(.*)" with link "(.*)" to be named "(.
   )
 end
 
-Then(/^the edited recommended link named "(.*)" should be listed on the recommended links index$/) do |title|
+Then(/^the edited external link named "(.*)" should be listed on the external links index$/) do |title|
   check_for_recommended_link_on_index_page(title: title)
 end
 
-When(/^I delete the recommended link named "(.*)" with link "(.*)"$/) do |title, link|
+When(/^I delete the external link named "(.*)" with link "(.*)"$/) do |title, link|
   delete_recommended_link(title: title, link: link)
 end
 
-Then(/^the recommended link named "(.*)" should not be listed on the recommended links index$/) do |title|
+Then(/^the external link named "(.*)" should not be listed on the external links index$/) do |title|
   check_for_absence_of_recommended_link_on_index_page(title: title)
 end
 
-When(/^I visit the recommended link$/) do
+When(/^I visit the external link$/) do
   visit recommended_link_path(@recommended_link || RecommendedLink.last)
 end
 
-Then(/^I should see the recommended links search results on the page$/) do
+Then(/^I should see the external links search results on the page$/) do
   expect(page).to have_selector('iframe')
   expect(find('iframe')[:src]).to include 'gov.uk/search?q=Tax+online'
 end

--- a/features/step_definitions/update_search_index_on_recommended_link_change_steps.rb
+++ b/features/step_definitions/update_search_index_on_recommended_link_change_steps.rb
@@ -1,18 +1,18 @@
-Then(/^the recommended link should have been sent to the mainstream index$/) do
+Then(/^the external link should have been sent to the mainstream index$/) do
   check_rummager_was_sent_an_exact_recommended_link_document(
     recommended_link: RecommendedLink.last,
     index: "mainstream"
   )
 end
 
-Then(/^the edited recommended link should have been sent to the mainstream index$/) do
+Then(/^the edited external link should have been sent to the mainstream index$/) do
   check_rummager_was_sent_an_exact_recommended_link_document(
     recommended_link: RecommendedLink.last,
     index: "mainstream"
   )
 end
 
-Then(/^the recommended link "(.*)" should have been deleted in the mainstream index$/) do |link|
+Then(/^the external link "(.*)" should have been deleted in the mainstream index$/) do |link|
   check_rummager_was_sent_a_recommended_link_delete(
     link: link,
     index: "mainstream"

--- a/features/support/recommended_links.rb
+++ b/features/support/recommended_links.rb
@@ -1,7 +1,7 @@
 def create_recommended_link(title: nil, link: nil, description: nil, keywords: nil)
   visit recommended_links_path
 
-  click_on 'New recommended link'
+  click_on 'New external link'
 
   fill_in 'Link', with: link if link
   fill_in 'Title', with: title if title
@@ -20,7 +20,7 @@ def edit_recommended_link(old_title: nil, old_link: nil, title: nil, description
     click_on old_title
   end
 
-  click_on "Edit recommended link"
+  click_on "Edit external link"
   fill_in 'Title', with: title if title
   fill_in 'Description', with: description if description
   fill_in 'Keywords', with: keywords if keywords
@@ -37,7 +37,7 @@ def delete_recommended_link(title: nil, link: nil)
     click_on title
   end
 
-  click_on "Delete recommended link"
+  click_on "Delete external link"
 end
 
 def check_for_recommended_link_on_index_page(title: nil)

--- a/features/update_search_index_on_recommended_link_change.feature
+++ b/features/update_search_index_on_recommended_link_change.feature
@@ -1,12 +1,12 @@
-Feature: Update search index on recommended change
+Feature: Update search index on external change
   As a search admin
-  I want my recommended link changes to be sent to the correct index
+  I want my external link changes to be sent to the correct index
   So that they can be used to alter the results of searches
 
-  Scenario: Creating a recommended link
-    When I create a new recommended link
-    Then the recommended link should have been sent to the mainstream index
-    When I edit the recommended link named "Tax online" with link "https://www.tax.service.gov.uk/" to be named "The new tax online"
-    Then the edited recommended link should have been sent to the mainstream index
-    When I delete the recommended link named "The new tax online" with link "https://www.tax.service.gov.uk/"
-    Then the recommended link "https://www.tax.service.gov.uk/" should have been deleted in the mainstream index
+  Scenario: Creating an external link
+    When I create a new external link
+    Then the external link should have been sent to the mainstream index
+    When I edit the external link named "Tax online" with link "https://www.tax.service.gov.uk/" to be named "The new tax online"
+    Then the edited external link should have been sent to the mainstream index
+    When I delete the external link named "The new tax online" with link "https://www.tax.service.gov.uk/"
+    Then the external link "https://www.tax.service.gov.uk/" should have been deleted in the mainstream index

--- a/lib/tasks/publish_external_links.rake
+++ b/lib/tasks/publish_external_links.rake
@@ -1,0 +1,8 @@
+desc "Ensure all external links in the database are present in rummager"
+task publish_external_links: :environment do
+  puts "Sending external links to rummager..."
+  RecommendedLink.all.each do |link|
+    puts "#{link.link}"
+    RummagerLinkSynchronize.put(link)
+  end
+end

--- a/lib/tasks/publish_recommended_links.rake
+++ b/lib/tasks/publish_recommended_links.rake
@@ -1,8 +1,0 @@
-desc "Ensure all recommended links in the database are present in Rummager"
-task publish_recommended_links: :environment do
-  puts "Sending recommended links to rummager..."
-  RecommendedLink.all.each do |link|
-    puts "#{link.link}"
-    RummagerLinkSynchronize.put(link)
-  end
-end


### PR DESCRIPTION
This will make their purpose clearer and reduce confusion with “best bets”.

Trello: https://trello.com/c/MUNBM24k/454-rename-recommended-links-to-external-links-in-search-admin