### PR TITLE
Expand the keywords field for external links

### DIFF
--- a/app/views/recommended_links/_form.html.erb
+++ b/app/views/recommended_links/_form.html.erb
@@ -12,7 +12,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.text_field :keywords, class: "form-control input-lg" %>
+    <%= f.text_area :keywords, class: "form-control input-lg" %>
   </div>
 
   <div class="form-group">


### PR DESCRIPTION
This commit changes the keywords field from a text box to a larger text area to show more keywords and become expandable by the user.

Trello: https://trello.com/c/IsCDm3uB/455-make-the-keywords-field-bigger-in-search-admin-for-external-links