### PR TITLE
Add the current release SHA to the footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,5 +40,7 @@
 </script>
 <% end %>
 
+<% content_for :footer_version, CURRENT_RELEASE_SHA %>
+
 <%# use the govuk_admin_foundation layout %>
 <%= render :template => 'layouts/govuk_admin_template' %>

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,0 +1,7 @@
+revision_file = File.join(Rails.root, "REVISION")
+if File.exist?(revision_file)
+  revision = File.read(revision_file).strip
+  CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
+else
+  CURRENT_RELEASE_SHA = "development".freeze
+end


### PR DESCRIPTION
This brings search-admin into line with other publishing and admin apps which display this value in the footer to make it easy to confirm which version of the app is deployed.