### PR TITLE
Configure search-admin with env vars

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,8 +1,6 @@
 default: &default
   adapter: mysql2
   encoding: utf8
-  username: search_admin
-  password: search_admin
 
 development:
   <<: *default
@@ -11,6 +9,12 @@ development:
 test: &test
   <<: *default
   database: search_admin_test
+  username: search_admin
+  password: search_admin
 
 cucumber:
   <<: *test
+
+production:
+  <<: *default
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,12 @@
+Airbrake.configure do |config|
+  if ENV.has_key?('ERRBIT_API_KEY')
+    config.api_key = ENV['ERRBIT_API_KEY']
+    config.host = "errbit.#{ENV['GOVUK_APP_DOMAIN']}"
+    config.secure = true
+    config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
+  else
+    # Adding production to the development environments causes Airbrake not
+    # to attempt to send notifications.
+    config.development_environments << 'production'
+  end
+end

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,0 +1,6 @@
+GDS::SSO.config do |config|
+  config.user_model     = 'User'
+  config.oauth_id       = ENV['OAUTH_ID']
+  config.oauth_secret   = ENV['OAUTH_SECRET']
+  config.oauth_root_url = Plek.current.find('signon')
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,3 +15,8 @@ development:
 
 test:
   secret_key_base: 9965640a8d8b3d60d00895a7b5f1f1bc065e936cea3e0191ebb820b29a03d1d78a3e68bce769badf2dede18dee8648f634c93c01af279a9221691435c2d1df0a
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
search-admin is moving to the new deployment pipeline.

Depends on https://github.com/alphagov/govuk-puppet/pull/5430

Trello: https://trello.com/c/tjUur3ec/462-move-search-admin-to-new-deployment-pipeline