### PR TITLE
Show more like this results

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -5,14 +5,14 @@ class ResultsController < ApplicationController
   def show
     @path = params[:base_path]
     @path = URI.parse(@path).path if @path.starts_with?('http')
-    @document = rummager.get("/content?link=#{@path}")
+    @document = Services.rummager.get("/content?link=#{@path}")
   rescue GdsApi::HTTPNotFound
     flash[:error] = "That URL wasn't found."
     redirect_to results_path
   end
 
   def destroy
-    rummager.delete!("/content?link=#{params[:id]}")
+    Services.rummager.delete!("/content?link=#{params[:id]}")
     flash[:notice] = "This search result will be removed soon. Please refresh this page to check."
     redirect_to result_path("result", base_path: params[:id])
   rescue GdsApi::HTTPNotFound
@@ -21,11 +21,5 @@ class ResultsController < ApplicationController
   rescue GdsApi::HTTPClientError => e
     flash[:error] = e.error_details['result']
     redirect_to results_path
-  end
-
-private
-
-  def rummager
-    SearchAdmin.services(:rummager)
   end
 end

--- a/app/controllers/similar_search_results_controller.rb
+++ b/app/controllers/similar_search_results_controller.rb
@@ -1,0 +1,39 @@
+class SimilarSearchResultsController < ApplicationController
+  def new
+    render :new, locals: default_locals
+  end
+
+  def show
+    base_path = params[:base_path]
+
+    render :show, locals: {
+      base_path: base_path,
+      results: MoreLikeThis.from_base_path(base_path)
+    }
+
+  rescue MoreLikeThis::NotFoundInSearch
+    render_with_error("Content item not found for #{base_path}")
+  rescue MoreLikeThis::NotTaggedToATaxon
+    render_with_error("The page #{base_path} isn't tagged to a taxon")
+  rescue MoreLikeThis::NoSearchResults
+    render_with_error("No search results found for #{base_path}")
+  end
+
+private
+
+  def render_with_error(message)
+    flash.now[:error] = message
+
+    render(
+      :new,
+      locals: default_locals,
+    )
+  end
+
+  def default_locals
+    {
+      base_path: params[:base_path],
+      results: [],
+    }
+  end
+end

--- a/app/listeners/rummager_notifier.rb
+++ b/app/listeners/rummager_notifier.rb
@@ -10,10 +10,10 @@ class RummagerNotifier
 
     if query && query.bets.any?
       es_doc = ElasticSearchBet.new(query)
-      SearchAdmin.services(:rummager_index_metasearch).add_document(es_doc.type, es_doc.id, es_doc.body)
+      Services.rummager_index_metasearch.add_document(es_doc.type, es_doc.id, es_doc.body)
     else
       es_doc_id = ElasticSearchBetIDGenerator.generate(query_string, match_type)
-      SearchAdmin.services(:rummager_index_metasearch).delete_document("best_bet", CGI.escape(es_doc_id))
+      Services.rummager_index_metasearch.delete_document("best_bet", CGI.escape(es_doc_id))
     end
   end
 end

--- a/app/models/elastic_search_mlt_result.rb
+++ b/app/models/elastic_search_mlt_result.rb
@@ -1,0 +1,13 @@
+class ElasticSearchMltResult
+  include ActiveModel::Model
+
+  VALID_FIELDS = %w(
+    title
+    link
+    format
+    es_score
+    content_store_document_type
+  ).freeze
+
+  attr_accessor(*VALID_FIELDS.map(&:to_sym))
+end

--- a/app/services/more_like_this.rb
+++ b/app/services/more_like_this.rb
@@ -1,0 +1,55 @@
+class MoreLikeThis
+  class Error < StandardError; end
+  class NotFoundInSearch < Error; end
+  class NotTaggedToATaxon < Error; end
+  class NoSearchResults < Error; end
+
+  attr_reader :base_path
+
+  def initialize(base_path)
+    @base_path = base_path
+  end
+
+  def self.from_base_path(base_path)
+    new(base_path).from_base_path
+  end
+
+  def from_base_path
+    raise NotFoundInSearch if content_item.nil?
+    raise NotTaggedToATaxon if tagged_taxon_content_id.nil?
+    raise NoSearchResults if search_results.empty?
+
+    search_results.reduce([]) do |mlt_results, search_result|
+      mlt_results << ElasticSearchMltResult.new(
+        search_result.slice(*ElasticSearchMltResult::VALID_FIELDS)
+      )
+    end
+  end
+
+private
+
+  def tagged_taxon_content_id
+    taxon_content_ids = content_item['taxons'] || []
+    return if taxon_content_ids.empty?
+
+    # TODO: handle multiple tagged taxons in results
+    taxon_content_ids.first
+  end
+
+  def search_results
+    Services.rummager.search(
+      similar_to: base_path,
+      start: 0,
+      count: 25,
+      filter_taxons: [tagged_taxon_content_id],
+      fields: %w(title link format content_store_document_type)
+    )['results']
+  end
+
+  def content_item
+    Services.rummager.search(
+      filter_link: base_path,
+      fields: %w(taxons)
+    )['results'].first
+  end
+end

--- a/app/services/rummager_link_synchronize.rb
+++ b/app/services/rummager_link_synchronize.rb
@@ -1,4 +1,4 @@
-module RummagerLinkSynchronize
+class RummagerLinkSynchronize
   def self.put(recommended_link, client: self.client)
     es_doc = ElasticSearchRecommendedLink.new(recommended_link)
     client.add_document("edition", es_doc.id, es_doc.details)
@@ -9,6 +9,6 @@ module RummagerLinkSynchronize
   end
 
   def self.client
-    SearchAdmin.services(:rummager_index_mainstream)
+    ::Services.rummager_index_mainstream
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,10 @@
   <li class='<%= controller_name == "results" ? "active" : nil %>'>
     <%= link_to 'Search results', results_path %>
   </li>
+
+  <li class='<%= controller_name == 'similar_search_results' ? 'active' : nil %>'>
+    <%= link_to 'Similar search results', new_similar_search_result_path %>
+  </li>
 <% end %>
 
 <% content_for :navbar_right do %>

--- a/app/views/similar_search_results/_form.html.erb
+++ b/app/views/similar_search_results/_form.html.erb
@@ -1,0 +1,8 @@
+<%= form_tag similar_search_result_path(:result), method: :get do %>
+  <div class="form-group">
+    <%= label_tag "Path or URL of search result (eg. /guidance/pupil-premium-reviews)" %>
+    <%= text_field_tag :base_path, base_path, type: :search, class: 'form-control' %>
+  </div>
+
+  <%= submit_tag 'Show similar search results', class: 'btn btn-primary btn-md' %>
+<% end %>

--- a/app/views/similar_search_results/_result.html.erb
+++ b/app/views/similar_search_results/_result.html.erb
@@ -1,0 +1,13 @@
+<tr>
+  <td><%= index + 1 %></td>
+  <td>
+    <%= link_to(
+      result.title,
+      Plek.new.website_root + result.link,
+      target: 'blank'
+    )%>
+  </td>
+  <td><%= result.es_score %></td>
+  <td><%= result.format %></td>
+  <td><%= result.content_store_document_type %></td>
+</tr>

--- a/app/views/similar_search_results/_results.html.erb
+++ b/app/views/similar_search_results/_results.html.erb
@@ -1,0 +1,24 @@
+<table class="table recommended-links-list table-bordered" data-module="filterable-table">
+  <thead>
+    <tr class="table-header">
+      <th>#</th>
+      <th>Title</th>
+      <th>Score</th>
+      <th>Format</th>
+      <th>Content store document type</th>
+    </tr>
+
+    <tr class="table-header if-no-js-hide table-header-secondary">
+      <th colspan="5">
+        <form class="table-filter">
+          <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter table">
+        </form>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% results.each_with_index do |result, index| %>
+      <%= render 'result', result: result, index: index %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/similar_search_results/new.html.erb
+++ b/app/views/similar_search_results/new.html.erb
@@ -1,0 +1,7 @@
+<ol class="breadcrumb">
+  <li class="active">Similar search results</li>
+</ol>
+
+<%= page_title 'Search for similar paged' %>
+
+<%= render 'form', base_path: base_path %>

--- a/app/views/similar_search_results/show.html.erb
+++ b/app/views/similar_search_results/show.html.erb
@@ -1,0 +1,11 @@
+<ol class="breadcrumb">
+  <li class="active">Similar search results</li>
+</ol>
+
+<%= page_title 'Similar search results' %>
+
+<%= render 'form', base_path: base_path %>
+
+<% if results.present? %>
+  <%= render 'results', results: results %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ module SearchAdmin
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.eager_load_paths += %W(#{config.root}/lib)
 
     config.action_view.default_form_builder = GenericFormBuilder
     config.action_view.field_error_proc = proc { |html_tag, _| html_tag }

--- a/config/initializers/services_and_listeners.rb
+++ b/config/initializers/services_and_listeners.rb
@@ -1,25 +1,5 @@
 require 'gds_api/rummager'
 
-module SearchAdmin
-  def self.services(name, service = nil)
-    @services ||= {}
-    @services[name] = service if service
-    @services[name]
-  end
-end
-
-# Services
-SearchAdmin.services(
-  :rummager_index_metasearch,
-  GdsApi::Rummager.new(Plek.current.find('rummager') + '/metasearch')
-)
-SearchAdmin.services(
-  :rummager_index_mainstream,
-  GdsApi::Rummager.new(Plek.current.find('rummager') + '/mainstream')
-)
-
-require 'gds_api/rummager'
-
 # Extend the adapters to allow us to request URLs directly.
 module GdsApi
   class Rummager < Base
@@ -34,7 +14,3 @@ module GdsApi
     end
   end
 end
-
-# Don't use caching to prevent just-deleted docs to show up.
-rummager = GdsApi::Rummager.new(Plek.current.find('search'), disable_cache: true)
-SearchAdmin.services(:rummager, rummager)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@ Rails.application.routes.draw do
   resources :queries
   resources :recommended_links, path: "/recommended-links"
   resources :results, only: [:index, :show, :destroy]
-  resources :similar_search_results, only: [:new, :show]
+  resources(
+    :similar_search_results,
+    only: [:new, :show],
+    path: 'similar-search-results'
+  )
 
   root 'queries#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :queries
   resources :recommended_links, path: "/recommended-links"
   resources :results, only: [:index, :show, :destroy]
+  resources :similar_search_results, only: [:new, :show]
 
   root 'queries#index'
 

--- a/features/similar_search_results.feature
+++ b/features/similar_search_results.feature
@@ -1,0 +1,11 @@
+Feature: Similar search results
+  As as a search admin
+  I want to be able to search for similar results
+  So I know what related content there is for a particular page
+
+  Scenario: Viewing more like this results
+    When I visit the similar search results form
+    And I type in a valid GOV.UK link with related items
+    Then I should see all related items
+
+

--- a/features/step_definitions/similar_search_results_steps.rb
+++ b/features/step_definitions/similar_search_results_steps.rb
@@ -1,0 +1,42 @@
+When(/^I visit the similar search results form$/) do
+  visit root_path
+  click_on 'Similar search results'
+end
+
+When(/^I type in a valid GOV\.UK link with related items$/) do
+  stub_request(
+    :get,
+    "https://search.test.gov.uk/search.json?fields%5B%5D=taxons&filter_link=/guidance/pupil-premium-reviews"
+  ).to_return(
+    body: {
+      'results' => [{
+        'link' => '/guidance/pupil-premium-reviews',
+        'taxons' => ['1ddd7a85-6c64-4b1e-9e54-55b50a0ae3f3']
+      }]
+    }.to_json
+  )
+
+  stub_request(
+    :get,
+    /https:\/\/search.test.gov.uk\/search.json\?.*similar_to=\/guidance\/pupil-premium-reviews.*/
+  ).to_return(
+    body: {
+      'results' => [{
+        'link' => '/similar-item',
+        'title' => 'Similar item',
+        'es_score' => 20.97,
+        'format' => 'detailed_guidance',
+        'content_store_document_type' => 'detailed_guide'
+      }]
+    }.to_json
+  )
+
+  fill_in 'base_path', with: '/guidance/pupil-premium-reviews'
+  click_on 'Show similar search result'
+end
+
+Then(/^I should see all related items$/) do
+  expect(current_path).to eq(similar_search_result_path(:result))
+  expect(page).to_not have_selector('.alert')
+  expect(page).to have_selector('table tbody tr', count: 1)
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,18 @@
+require 'gds_api/rummager'
+
+module Services
+  def self.rummager_index_metasearch
+    @rummager_index_metasearch ||=
+      GdsApi::Rummager.new(Plek.current.find('rummager') + '/metasearch')
+  end
+
+  def self.rummager_index_mainstream
+    @rummager_index_mainstream ||=
+      GdsApi::Rummager.new(Plek.current.find('rummager') + '/mainstream')
+  end
+
+  def self.rummager
+    @rummager ||=
+      GdsApi::Rummager.new(Plek.current.find('search'), disable_cache: true)
+  end
+end

--- a/spec/models/elastic_search_mlt_result_spec.rb
+++ b/spec/models/elastic_search_mlt_result_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe ElasticSearchMltResult do
+  let(:attributes) do
+    {
+      title: 'A related link',
+      link: '/related-link',
+      format: 'guide',
+      es_score: 20.21,
+      content_store_document_type: 'guide'
+    }
+  end
+  let(:result) { described_class.new(attributes) }
+
+  it 'assigns the title' do
+    expect(result.title).to eq(attributes[:title])
+  end
+
+  it 'assigns the link' do
+    expect(result.link).to eq(attributes[:link])
+  end
+
+  it 'assigns the format' do
+    expect(result.format).to eq(attributes[:format])
+  end
+
+  it 'assigns the es_score' do
+    expect(result.es_score).to eq(attributes[:es_score])
+  end
+
+  it 'assigns the content_store_document_type' do
+    expect(result.content_store_document_type).to eq(attributes[:content_store_document_type])
+  end
+end

--- a/spec/services/more_like_this_spec.rb
+++ b/spec/services/more_like_this_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+RSpec.describe MoreLikeThis do
+  describe '.from_base_path' do
+    context 'with an unknown base path in search' do
+      before do
+        allow(Services.rummager).to receive(:search)
+          .with(
+            filter_link: '/unknown',
+            fields: ['taxons']
+          )
+          .and_return("results" => [])
+      end
+
+      it 'raises an custom not found exception' do
+        expect { described_class.from_base_path('/unknown') }.to raise_error(
+          MoreLikeThis::NotFoundInSearch
+        )
+      end
+    end
+
+    context 'with a content item without a taxon link' do
+      before do
+        allow(Services.rummager).to receive(:search)
+          .with(
+            filter_link: '/item',
+            fields: ['taxons']
+          )
+          .and_return("results" => [
+            'taxons' => []
+          ])
+      end
+
+      it 'raises a custom not tagged to a taxon exception' do
+        expect { described_class.from_base_path('/item') }.to raise_error(
+          MoreLikeThis::NotTaggedToATaxon
+        )
+      end
+    end
+
+    context 'without any search results' do
+      before do
+        allow(Services.rummager).to receive(:search)
+          .with(
+            filter_link: '/item',
+            fields: ['taxons']
+          )
+          .and_return("results" => [
+            'taxons' => ['714bc7d1-afb0-4e10-9558-268da5dbbbba']
+          ])
+
+        allow(Services.rummager).to receive(:search)
+          .with(
+            hash_including(
+              similar_to: '/item',
+              filter_taxons: ['714bc7d1-afb0-4e10-9558-268da5dbbbba']
+            )
+          )
+          .and_return('results' => [])
+      end
+
+      it 'raises a custom exception about no search results available' do
+        expect { described_class.from_base_path('/item') }.to raise_error(
+          MoreLikeThis::NoSearchResults
+        )
+      end
+    end
+
+    context 'with a valid base path with similar results' do
+      before do
+        allow(Services.rummager).to receive(:search)
+          .with(
+            filter_link: '/item',
+            fields: ['taxons']
+          )
+          .and_return("results" => [
+            'taxons' => ['714bc7d1-afb0-4e10-9558-268da5dbbbba']
+          ])
+
+        allow(Services.rummager).to receive(:search)
+          .with(
+            hash_including(
+              similar_to: '/item',
+              filter_taxons: ['714bc7d1-afb0-4e10-9558-268da5dbbbba']
+            )
+          )
+          .and_return('results' => [
+            {
+              'link' => '/similar-item',
+              'title' => 'Similar item',
+              'es_score' => 20.97,
+              'format' => 'detailed_guidance',
+              'content_store_document_type' => 'detailed_guide'
+            }
+          ])
+      end
+
+      it 'returns an array of ElasticSearch more like this objects' do
+        results = described_class.from_base_path('/item')
+
+        expect(results.length).to eq(1)
+        result = results.first
+
+        expect(result).to be_a(ElasticSearchMltResult)
+        expect(result.title).to eq('Similar item')
+        expect(result.es_score).to eq(20.97)
+        expect(result.link).to eq('/similar-item')
+        expect(result.format).to eq('detailed_guidance')
+        expect(result.content_store_document_type).to eq('detailed_guide')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds new functionality to Search Admin so we can search for "more like this" links and see the results in a user friendly way.

This will be helpful when going through the results with the Information Architects on the team to determine what pieces of content have good related links and which one don't.

Part of: https://trello.com/c/0GcWhX1t/402-list-current-top-more-like-this-links-for-all-education-content

It looks like this:

<img width="1248" alt="screen shot 2017-02-15 at 11 28 12" src="https://cloud.githubusercontent.com/assets/416701/22972523/e1e136f4-f371-11e6-8fa8-c525aaba8a8b.png">
