### PR TITLE
Rebuild elasticsearch index

### DIFF
--- a/app/controllers/bets_controller.rb
+++ b/app/controllers/bets_controller.rb
@@ -5,7 +5,7 @@ class BetsController < ApplicationController
     @bet = Bet.new(create_params)
 
     if @bet.save
-      store_query_for_rummager(@bet.query)
+      store_query_for_rummager(@bet.query, :create)
       send_change_notification
 
       redirect_to query_path(@bet.query), notice: 'Bet created'
@@ -23,7 +23,7 @@ class BetsController < ApplicationController
     @bet = bet
 
     if @bet.update_attributes(bet_params)
-      store_query_for_rummager(@bet.query)
+      store_query_for_rummager(@bet.query, :update)
       send_change_notification
 
       redirect_to query_path(@bet.query), notice: 'Bet updated'
@@ -37,7 +37,7 @@ class BetsController < ApplicationController
     @bet = bet
 
     if @bet.destroy
-      store_query_for_rummager(@bet.query)
+      store_query_for_rummager(@bet.query, :update_bets)
       send_change_notification
 
       flash.notice = 'Bet deleted'

--- a/app/controllers/concerns/notifiable.rb
+++ b/app/controllers/concerns/notifiable.rb
@@ -1,13 +1,13 @@
 module Notifiable
   extend ActiveSupport::Concern
 
-  def store_query_for_rummager(query)
+  def store_query_for_rummager(query, action)
     @attributes_to_send ||= []
-    @attributes_to_send.push [query.query, query.match_type]
+    @attributes_to_send.push [query, action]
   end
 
   def send_change_notification
-    attributes_to_send = @attributes_to_send.reject(&:blank?)
-    RummagerNotifier.notify(attributes_to_send)
+    queries_to_send = @attributes_to_send.reject(&:blank?)
+    RummagerNotifier.notify(queries_to_send)
   end
 end

--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -15,7 +15,7 @@ class QueriesController < ApplicationController
   def create
     query = Query.new(query_params)
     if query.save
-      store_query_for_rummager(query)
+      store_query_for_rummager(query, :create)
       send_change_notification
 
       redirect_to query_path(query), notice: "Your query was created successfully"
@@ -48,10 +48,8 @@ class QueriesController < ApplicationController
   def update
     query = find_query
 
-    store_query_for_rummager(query)
-
     if query.update_attributes(query_params)
-      store_query_for_rummager(query)
+      store_query_for_rummager(query, :update)
       send_change_notification
 
       redirect_to query_path(query), notice: "Your query was updated successfully"
@@ -65,7 +63,7 @@ class QueriesController < ApplicationController
     query = find_query
 
     if query.destroy
-      store_query_for_rummager(query)
+      store_query_for_rummager(query, :delete)
       send_change_notification
 
       redirect_to queries_path, notice: "Your query was deleted successfully"

--- a/app/listeners/rummager_notifier.rb
+++ b/app/listeners/rummager_notifier.rb
@@ -1,19 +1,17 @@
 class RummagerNotifier
-  def self.notify(changed_query_match_type_pairs)
-    changed_query_match_type_pairs.each do |(query_string, match_type)|
-      update_elasticsearch(query_string, match_type)
+  def self.notify(queries_with_action)
+    queries_with_action.each do |query, action|
+      update_elasticsearch(query, action)
     end
   end
 
-  def self.update_elasticsearch(query_string, match_type)
-    query = Query.where(query: query_string, match_type: match_type).first
-
-    if query && query.bets.any?
+  def self.update_elasticsearch(query, action)
+    if action == :delete || (action == :update_bets && query.bets.empty?)
+      es_doc_id = ElasticSearchBetIDGenerator.generate(query.query, query.match_type)
+      Services.rummager_index_metasearch.delete_document("best_bet", CGI.escape(es_doc_id))
+    elsif query.bets.any? # don't create ES entry until query has some bets
       es_doc = ElasticSearchBet.new(query)
       Services.rummager_index_metasearch.add_document(es_doc.type, es_doc.id, es_doc.body)
-    else
-      es_doc_id = ElasticSearchBetIDGenerator.generate(query_string, match_type)
-      Services.rummager_index_metasearch.delete_document("best_bet", CGI.escape(es_doc_id))
     end
   end
 end

--- a/features/support/best_bets.rb
+++ b/features/support/best_bets.rb
@@ -123,9 +123,7 @@ end
 
 def check_rummager_was_sent_a_best_bet_delete(query_es_ids)
   query_es_ids.each do |id|
-    # The `delete` happens twice because it is triggered when
-    # creating a new query with no bets
-    assert_rummager_deleted_item(id, index: "metasearch", times: 1)
+    assert_rummager_deleted_item(id, index: "metasearch")
   end
 end
 

--- a/features/support/best_bets.rb
+++ b/features/support/best_bets.rb
@@ -125,7 +125,7 @@ def check_rummager_was_sent_a_best_bet_delete(query_es_ids)
   query_es_ids.each do |id|
     # The `delete` happens twice because it is triggered when
     # creating a new query with no bets
-    assert_rummager_deleted_item(id, index: "metasearch", times: 2)
+    assert_rummager_deleted_item(id, index: "metasearch", times: 1)
   end
 end
 

--- a/lib/tasks/reindex_best_bets.rake
+++ b/lib/tasks/reindex_best_bets.rake
@@ -1,0 +1,23 @@
+desc "Resend all local queries to rummager to be reindexed"
+task reindex_best_bets: :environment do
+  message = <<-MSG
+    Rebuilding the elasticsearch index will just resend all locally stored best bets across to
+    be inserted in to elasticsearch. This means that any orphaned entried in the elasticsearch
+    index would still exist. This can be avoided by running the below rake task on Rummager
+    before rebuilding the index.
+
+    bundle exec rake rummager:switch_to_empty_index RUMMAGER_INDEX=metasearch
+  MSG
+
+  puts message
+
+  puts "Starting to reindex #{Query.count} best bets in rummager"
+  start = Time.now.to_f
+
+  Query.all.each do |query|
+    puts "Processing: #{query.query} (#{query.match_type})"
+    RummagerNotifier.update_elasticsearch(query, :create_or_update)
+  end
+
+  puts "Finished reindexing best bets in rummager (#{(Time.now.to_f - start).round(2)} sec)"
+end

--- a/spec/controllers/bets_controller_spec.rb
+++ b/spec/controllers/bets_controller_spec.rb
@@ -42,7 +42,7 @@ describe BetsController do
       post :create, bet: bet_params
 
       expect(RummagerNotifier).to have_received(:notify)
-        .with([[query.query, query.match_type]])
+        .with([[query, :create]])
     end
 
     it "redirects to the query show when create is successful" do
@@ -68,7 +68,7 @@ describe BetsController do
       put :update, id: bet.id, bet: bet_params
 
       expect(RummagerNotifier).to have_received(:notify)
-        .with([[query.query, query.match_type]])
+        .with([[query, :update]])
     end
 
     it "redirects to the query show when update is successful" do

--- a/spec/controllers/queries_controller_spec.rb
+++ b/spec/controllers/queries_controller_spec.rb
@@ -39,7 +39,7 @@ describe QueriesController do
       it "notifies the world of the new query" do
         post :create, query: query_params
         expect(RummagerNotifier).to have_received(:notify)
-          .with([%w(jobs exact)])
+          .with([[Query.last, :create]])
       end
     end
 
@@ -94,7 +94,7 @@ describe QueriesController do
       it "notifies the world of the new query" do
         update_query
         expect(RummagerNotifier).to have_received(:notify)
-          .with([%w(tax exact), %w(jobs exact)])
+          .with([[query, :update]])
       end
     end
 
@@ -142,7 +142,7 @@ describe QueriesController do
       it "notifies the world of the deletion" do
         delete_query
         expect(RummagerNotifier).to have_received(:notify)
-          .with([%w(tax exact)])
+          .with([[query, :delete]])
       end
     end
   end


### PR DESCRIPTION
Currently, the local bests bets data is out of sync with what is stored in elasticsearch. As we can not easily compare the two datasets, the easiest approach is to reset the elasticsearch index for `metasearch` and the reindex the local data.

https://trello.com/c/yPzGbJSv/56-investigate-bugs-with-editing-best-bets-in-search-admin