### PR TITLE
Update nokogiri gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
     mysql2 (0.4.5)
     netrc (0.11.0)
     nio4r (2.0.0)
-    nokogiri (1.7.1)
+    nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
     null_logger (0.0.1)
     oauth2 (1.3.1)


### PR DESCRIPTION
Fun fact: The Japanese saw or nokogiri (鋸) is a type of saw used in woodworking and Japanese carpentry that cuts on the pull stroke, unlike most European saws that cut on the push stroke.