### PR TITLE
External link url must contain a host

### DIFF
--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -2,13 +2,19 @@ require 'uri'
 
 class UrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    valid = begin
-      URI.parse(value).is_a?(URI::HTTP)
-    rescue URI::InvalidURIError
-      false
+    uri = parse(value)
+    unless uri&.host
+      msg = options[:message] || (uri ? "does not have a valid host" : "is an invalid URL")
+      record.errors[attribute] << msg
     end
-    unless valid
-      record.errors[attribute] << (options[:message] || "is an invalid URL")
-    end
+  end
+
+private
+
+  def parse(value)
+    uri = URI.parse(value)
+    uri.is_a?(URI::HTTP) ? uri : nil
+  rescue URI::InvalidURIError
+    nil
   end
 end

--- a/spec/models/recommended_link_spec.rb
+++ b/spec/models/recommended_link_spec.rb
@@ -37,7 +37,17 @@ describe RecommendedLink do
     it 'is invalid with an incomplete link' do
       attributes = attributes_for(:recommended_link, link: 'www.hello-world.com')
 
-      expect(new_recommended_link_with(attributes)).not_to be_valid
+      record = new_recommended_link_with(attributes)
+      expect(record).not_to be_valid
+      expect(record.errors.full_messages).to eq(["Link is an invalid URL"])
+    end
+
+    it 'is invalid with a link without a host' do
+      attributes = attributes_for(:recommended_link, link: 'http:/path-not-host')
+
+      record = new_recommended_link_with(attributes)
+      expect(record).not_to be_valid
+      expect(record.errors.full_messages).to eq(["Link does not have a valid host"])
     end
 
     it "is invalid with a duplicate link" do


### PR DESCRIPTION
While the url `http:/path-to-page` is a valida URL it is not
valid for our purpose as we require the host that we are redirecting
to.

https://trello.com/c/nQfP94ph/312-search-admin-url-validation-in-search-admin-breaks-if-theres-only-one-slash