### PR TITLE
Add content ID field to RecommendedLink

### DIFF
--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -9,7 +9,7 @@ class RecommendedLinksController < ApplicationController
   end
 
   def new
-    @recommended_link = RecommendedLink.new
+    @recommended_link = RecommendedLink.new(content_id: SecureRandom.uuid)
   end
 
   def create
@@ -35,7 +35,7 @@ class RecommendedLinksController < ApplicationController
 
   def update
     @recommended_link = find_recommended_link
-    old_recommended_link = RecommendedLink.new(link: @recommended_link.link)
+    old_recommended_link = RecommendedLink.new(link: @recommended_link.link, content_id: @recommended_link.content_id)
 
     if @recommended_link.update_attributes(update_recommended_link_params)
 
@@ -74,7 +74,7 @@ private
   def create_recommended_link_params
     params.require(:recommended_link)
       .permit(:link, :title, :description, :keywords, :comment)
-      .merge(user_id: current_user.id)
+      .merge(user_id: current_user.id, content_id: SecureRandom.uuid)
   end
 
   def update_recommended_link_params

--- a/app/models/recommended_link.rb
+++ b/app/models/recommended_link.rb
@@ -1,6 +1,7 @@
 class RecommendedLink < ApplicationRecord
-  validates :title, :link, :description, presence: true
+  validates :title, :link, :description, :content_id, presence: true
   validates :link, uniqueness: true, url: true
+  validates :content_id, uniqueness: true
 
   def format
     uri = URI(link)

--- a/db/migrate/20171214153332_add_content_id_to_recommended_links.rb
+++ b/db/migrate/20171214153332_add_content_id_to_recommended_links.rb
@@ -1,0 +1,14 @@
+class AddContentIdToRecommendedLinks < ActiveRecord::Migration[5.0]
+  def up
+    add_column :recommended_links, :content_id, "char(36)"
+    add_index :recommended_links, :content_id, unique: true
+
+    RecommendedLink.all.each do |link|
+      link.update_attributes(content_id: SecureRandom.uuid())
+    end
+  end
+
+  def down
+    remove_column :recommended_links, :content_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170202095022) do
+ActiveRecord::Schema.define(version: 20171214153332) do
 
   create_table "bets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string  "link"
@@ -36,6 +36,8 @@ ActiveRecord::Schema.define(version: 20170202095022) do
     t.text    "keywords",    limit: 65535
     t.text    "comment",     limit: 65535
     t.integer "user_id"
+    t.string  "content_id",  limit: 36
+    t.index ["content_id"], name: "index_recommended_links_on_content_id", unique: true, using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -13,41 +12,41 @@
 
 ActiveRecord::Schema.define(version: 20170202095022) do
 
-  create_table "bets", force: :cascade do |t|
-    t.string  "link",     limit: 255
-    t.integer "position", limit: 4,     default: 1
+  create_table "bets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string  "link"
+    t.integer "position",               default: 1
     t.text    "comment",  limit: 65535
     t.boolean "manual",                 default: false
-    t.integer "query_id", limit: 4
+    t.integer "query_id"
     t.boolean "is_best",                default: true
-    t.integer "user_id",  limit: 4
+    t.integer "user_id"
   end
 
-  create_table "queries", force: :cascade do |t|
-    t.string   "query",      limit: 255
-    t.string   "match_type", limit: 255
+  create_table "queries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "query"
+    t.string   "match_type"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "recommended_links", force: :cascade do |t|
-    t.string  "title",       limit: 255
-    t.string  "link",        limit: 255
+  create_table "recommended_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string  "title"
+    t.string  "link"
     t.text    "description", limit: 65535
     t.text    "keywords",    limit: 65535
     t.text    "comment",     limit: 65535
-    t.integer "user_id",     limit: 4
+    t.integer "user_id"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string  "name",                    limit: 255
-    t.string  "email",                   limit: 255
-    t.string  "uid",                     limit: 255
-    t.string  "organisation_slug",       limit: 255
-    t.string  "permissions",             limit: 255
-    t.boolean "remotely_signed_out",                 default: false
-    t.boolean "disabled",                            default: false
-    t.string  "organisation_content_id", limit: 255
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string  "name"
+    t.string  "email"
+    t.string  "uid"
+    t.string  "organisation_slug"
+    t.string  "permissions"
+    t.boolean "remotely_signed_out",     default: false
+    t.boolean "disabled",                default: false
+    t.string  "organisation_content_id"
   end
 
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -34,6 +34,7 @@ FactoryGirl.define do
     link "https://www.tax.service.gov.uk/"
     description "File your self assessment online."
     keywords "tax, self assessment, hmrc"
+    content_id { SecureRandom.uuid }
   end
 
   factory :user do

--- a/spec/models/elastic_search_recommended_link_spec.rb
+++ b/spec/models/elastic_search_recommended_link_spec.rb
@@ -1,7 +1,14 @@
 require 'spec_helper'
 
 describe ElasticSearchRecommendedLink do
-  let(:recommended_link) { create(:recommended_link, title: 'Tax', link: 'https://www.tax.service.gov.uk/', description: 'Self assessment', keywords: 'self, assessment, tax') }
+  let(:recommended_link) {
+    create(:recommended_link,
+    title: 'Tax',
+    link: 'https://www.tax.service.gov.uk/',
+    description: 'Self assessment',
+    keywords: 'self, assessment, tax',
+    content_id: SecureRandom.uuid)
+  }
 
   it "builds an elasticsearch doc from the provided recommended link" do
     es_recommended_link = ElasticSearchRecommendedLink.new(recommended_link)


### PR DESCRIPTION
This is in preparation for publishing recommended links to the publishing API rather than rummager. Everything stored in the publishing API needs a UUID content ID.

Ensure that content IDs are generated for existing links.

Also regenerate schema.rb. I think these changes are caused by the Rails upgrade - I can't see any differences in the MySQL schema itself.

https://trello.com/c/rDurYmt8/525-send-external-links-from-search-admin-to-the-publishing-api