### PR TITLE
Publish recommended links to publishing api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner', '~> 1.6.2'
   gem 'factory_bot_rails', '~> 4.8.2'
+  gem 'govuk-content-schema-test-helpers', '~> 1.6.0'
   gem 'webmock', '~> 3.1.1'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
     gherkin (5.0.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    govuk-content-schema-test-helpers (1.6.0)
+      json-schema (~> 2.8.0)
     govuk-lint (3.4.0)
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
@@ -139,6 +141,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json-schema (2.8.0)
+      addressable (>= 2.4)
     jwt (1.5.6)
     kgio (2.11.0)
     link_header (0.0.8)
@@ -326,6 +330,7 @@ DEPENDENCIES
   gds-api-adapters (~> 47.9.1)
   gds-sso (~> 13.5.0)
   generic_form_builder (~> 0.13.0)
+  govuk-content-schema-test-helpers (~> 1.6.0)
   govuk-lint
   govuk_admin_template
   govuk_app_config (~> 0.2.0)

--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -14,7 +14,9 @@ class RecommendedLinksController < ApplicationController
 
   def create
     @recommended_link = RecommendedLink.new(create_recommended_link_params)
+
     if @recommended_link.save
+      ExternalContentPublisher.publish(@recommended_link)
       RummagerLinkSynchronize.put(@recommended_link)
 
       redirect_to recommended_link_path(@recommended_link), notice: "Your external link was created successfully"
@@ -45,6 +47,7 @@ class RecommendedLinksController < ApplicationController
       end
 
       RummagerLinkSynchronize.put(@recommended_link)
+      ExternalContentPublisher.publish(@recommended_link)
 
       redirect_to recommended_link_path(@recommended_link), notice: "Your external link was updated successfully"
     else
@@ -58,6 +61,7 @@ class RecommendedLinksController < ApplicationController
 
     if recommended_link.destroy
       RummagerLinkSynchronize.delete(recommended_link)
+      ExternalContentPublisher.unpublish(recommended_link)
 
       redirect_to recommended_links_path, notice: "Your external link was deleted successfully"
     else

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,6 +1,14 @@
 require 'gds_api/rummager'
+require 'gds_api/publishing_api_v2'
 
 module Services
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
+    )
+  end
+
   def self.rummager_index_metasearch
     @rummager_index_metasearch ||=
       GdsApi::Rummager.new(Plek.current.find('rummager') + '/metasearch')

--- a/app/presenters/external_content_presenter.rb
+++ b/app/presenters/external_content_presenter.rb
@@ -1,0 +1,26 @@
+class ExternalContentPresenter
+  def initialize(recommended_link)
+    @recommended_link = recommended_link
+  end
+
+  def present_for_publishing_api
+    {
+      description: @recommended_link.description,
+      details: {
+        hidden_search_terms: hidden_search_terms,
+        url: @recommended_link.link,
+      },
+      document_type: "external_content",
+      publishing_app: "search-admin",
+      schema_name: "external_content",
+      title: @recommended_link.title,
+      update_type: "minor",
+    }
+  end
+
+private
+
+  def hidden_search_terms
+    [@recommended_link.keywords].compact
+  end
+end

--- a/app/services/external_content_publisher.rb
+++ b/app/services/external_content_publisher.rb
@@ -1,0 +1,13 @@
+class ExternalContentPublisher
+  def self.publish(recommended_link)
+    payload = ExternalContentPresenter.new(recommended_link)
+      .present_for_publishing_api
+
+    Services.publishing_api.put_content(recommended_link.content_id, payload)
+    Services.publishing_api.publish(recommended_link.content_id)
+  end
+
+  def self.unpublish(recommended_link)
+    Services.publishing_api.unpublish(recommended_link.content_id, type: "gone")
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,12 +8,14 @@ require 'cucumber/rails'
 require 'cucumber/rspec/doubles'
 
 require 'webmock/cucumber'
+require 'gds_api/test_helpers/publishing_api_v2'
 require 'gds_api/test_helpers/rummager'
 
 WebMock.disable_net_connect!
 
 World(FactoryBot::Syntax::Methods)
 World(GdsApi::TestHelpers::Rummager)
+World(GdsApi::TestHelpers::PublishingApiV2)
 
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any

--- a/features/support/recommended_links.rb
+++ b/features/support/recommended_links.rb
@@ -1,4 +1,7 @@
 def create_recommended_link(title: nil, link: nil, description: nil, keywords: nil)
+  stub_any_publishing_api_put_content
+  stub_any_publishing_api_publish
+
   visit recommended_links_path
 
   click_on 'New external link'
@@ -12,6 +15,9 @@ def create_recommended_link(title: nil, link: nil, description: nil, keywords: n
 end
 
 def edit_recommended_link(old_title: nil, old_link: nil, title: nil, description: nil, keywords: nil, comment: nil)
+  stub_any_publishing_api_put_content
+  stub_any_publishing_api_publish
+
   visit recommended_links_path
 
   recommended_link = RecommendedLink.where(link: old_link).last
@@ -29,6 +35,8 @@ def edit_recommended_link(old_title: nil, old_link: nil, title: nil, description
 end
 
 def delete_recommended_link(title: nil, link: nil)
+  stub_any_publishing_api_unpublish
+
   visit recommended_links_path
 
   recommended_link = RecommendedLink.where(link: link).last

--- a/spec/presenters/external_content_presenter_spec.rb
+++ b/spec/presenters/external_content_presenter_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe ExternalContentPresenter do
+  context "for the publishing API" do
+    it "presents minimal external content to match the schema" do
+      payload = ExternalContentPresenter.new(recommended_link).present_for_publishing_api
+
+      expect(payload[:description]).to eq("Public data to help people understand how the government works")
+      expect(payload[:title]).to eq("Data.gov.uk")
+      expect(payload[:details][:url]).to eq("http://www.data.gov.uk/")
+      expect(payload[:details][:hidden_search_terms]).to eq([])
+
+      assert_valid_content_item(payload)
+    end
+
+    it "presents search keywords" do
+      link = recommended_link(keywords: "data, open data, api")
+
+      payload = ExternalContentPresenter.new(link).present_for_publishing_api
+
+      expect(payload[:details][:hidden_search_terms]).to eq(["data, open data, api"])
+
+      assert_valid_content_item(payload)
+    end
+
+    it "presents publishing details" do
+      payload = ExternalContentPresenter.new(recommended_link).present_for_publishing_api
+
+      expect(payload[:document_type]).to eq("external_content")
+      expect(payload[:publishing_app]).to eq("search-admin")
+      expect(payload[:schema_name]).to eq("external_content")
+      expect(payload[:update_type]).to eq("minor")
+    end
+
+    def recommended_link(details = {})
+      RecommendedLink.new({
+        content_id: "some-content-id",
+        description: "Public data to help people understand how the government works",
+        link: "http://www.data.gov.uk/",
+        title: "Data.gov.uk",
+      }.merge(details))
+    end
+
+    def assert_valid_content_item(payload)
+      validator = GovukContentSchemaTestHelpers::Validator.new(
+        "external_content",
+        "schema",
+        payload
+      )
+
+      expect(validator).to be_valid
+    end
+  end
+end

--- a/spec/services/external_content_publisher_spec.rb
+++ b/spec/services/external_content_publisher_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe ExternalContentPublisher do
+  it "saves and publishes a recommended link to the publishing API" do
+    link = RecommendedLink.new(
+      content_id: "some-content-id",
+      description: "Public data to help people understand how the government works",
+      link: "http://www.data.gov.uk/",
+      title: "Data.gov.uk",
+    )
+
+    expect(Services.publishing_api).to receive(:put_content) do |content_id, payload|
+      expect(content_id).to eq("some-content-id")
+      expect(payload[:details][:url]).to eq("http://www.data.gov.uk/")
+    end
+    expect(Services.publishing_api).to receive(:publish).with("some-content-id")
+
+    ExternalContentPublisher.publish(link)
+  end
+
+  it "unpublishes a recommended link in the publishing API" do
+    link = RecommendedLink.new(content_id: "some-content-id")
+
+    expect(Services.publishing_api).to receive(:unpublish).with("some-content-id", type: "gone")
+
+    ExternalContentPublisher.unpublish(link)
+  end
+end

--- a/spec/services/external_content_publisher_spec.rb
+++ b/spec/services/external_content_publisher_spec.rb
@@ -1,28 +1,51 @@
 require 'spec_helper'
 
 RSpec.describe ExternalContentPublisher do
-  it "saves and publishes a recommended link to the publishing API" do
-    link = RecommendedLink.new(
+  let(:link) {
+    RecommendedLink.new(
       content_id: "some-content-id",
       description: "Public data to help people understand how the government works",
       link: "http://www.data.gov.uk/",
       title: "Data.gov.uk",
     )
+  }
 
-    expect(Services.publishing_api).to receive(:put_content) do |content_id, payload|
-      expect(content_id).to eq("some-content-id")
-      expect(payload[:details][:url]).to eq("http://www.data.gov.uk/")
+  context "publishing" do
+    it "saves and publishes a recommended link to the publishing API" do
+      expect(Services.publishing_api).to receive(:put_content) do |content_id, payload|
+        expect(content_id).to eq("some-content-id")
+        expect(payload[:details][:url]).to eq("http://www.data.gov.uk/")
+      end
+      expect(Services.publishing_api).to receive(:publish).with("some-content-id")
+
+      ExternalContentPublisher.publish(link)
     end
-    expect(Services.publishing_api).to receive(:publish).with("some-content-id")
 
-    ExternalContentPublisher.publish(link)
+    it "raises an error if saving the link fails" do
+      stub_request(:put, "https://publishing-api.test.gov.uk/v2/content/some-content-id").to_return(status: 400)
+
+      expect { ExternalContentPublisher.publish(link) }.to raise_error(GdsApi::HTTPErrorResponse)
+    end
+
+    it "raises an error if publishing fails" do
+      stub_request(:put, "https://publishing-api.test.gov.uk/v2/content/some-content-id").to_return(status: 200)
+      stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/some-content-id/publish").to_return(status: 500)
+
+      expect { ExternalContentPublisher.publish(link) }.to raise_error(GdsApi::HTTPErrorResponse)
+    end
   end
 
-  it "unpublishes a recommended link in the publishing API" do
-    link = RecommendedLink.new(content_id: "some-content-id")
+  context "unpublishing" do
+    it "unpublishes a recommended link in the publishing API" do
+      expect(Services.publishing_api).to receive(:unpublish).with("some-content-id", type: "gone")
 
-    expect(Services.publishing_api).to receive(:unpublish).with("some-content-id", type: "gone")
+      ExternalContentPublisher.unpublish(link)
+    end
 
-    ExternalContentPublisher.unpublish(link)
+    it "raises an error if unpublishing fails" do
+      stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/some-content-id/unpublish").to_return(status: 404)
+
+      expect { ExternalContentPublisher.unpublish(link) }.to raise_error(GdsApi::HTTPErrorResponse)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,4 +38,11 @@ RSpec.configure do |config|
   config.before(:each, type: 'controller') do
     login_as_stub_user
   end
+
+  require 'govuk-content-schema-test-helpers'
+
+  GovukContentSchemaTestHelpers.configure do |schema_config|
+    schema_config.schema_type = 'publisher_v2'
+    schema_config.project_root = Rails.root
+  end
 end


### PR DESCRIPTION
Save and publish recommended links in the publishing API as well as rummager. This will let rummager ingest these links from the publishing API's message queue, reducing the number of publishing apps which index pages in rummager directly.

We'll remove the rummager publishing step once we've fully migrated this format to the new index.

https://trello.com/c/rDurYmt8/525-send-external-links-from-search-admin-to-the-publishing-api