### PR TITLE
Replace factory_girl_rails with factory_bot_rails 🤖

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ end
 group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner', '~> 1.6.2'
-  gem 'factory_girl_rails', '~> 4.9.0'
+  gem 'factory_bot_rails', '~> 4.8.2'
   gem 'webmock', '~> 3.1.1'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,10 +91,10 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -323,7 +323,7 @@ PLATFORMS
 DEPENDENCIES
   cucumber-rails
   database_cleaner (~> 1.6.2)
-  factory_girl_rails (~> 4.9.0)
+  factory_bot_rails (~> 4.8.2)
   gds-api-adapters (~> 47.9.1)
   gds-sso (~> 13.2.0)
   generic_form_builder (~> 0.13.0)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,7 +12,7 @@ require 'gds_api/test_helpers/rummager'
 
 WebMock.disable_net_connect!
 
-World(FactoryGirl::Syntax::Methods)
+World(FactoryBot::Syntax::Methods)
 World(GdsApi::TestHelpers::Rummager)
 
 # Capybara defaults to CSS3 selectors rather than XPath.

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence :numeric_position do |n|
     n
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
   config.order = "random"
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   config.before(:each) do
     # rummager URLs are of the form: http://rummager.dev.gov.uk/mainstream/document/http://test.dev.gov.uk


### PR DESCRIPTION
This looks like a downgrade from 4.9.0 to 4.8.2, but factory_girl_rails 4.9.0 is a special release which just contains a deprecation warning. 4.8.2 is the latest release of factory_bot_rails.

Ironically, this is one upgrade which dependabot can't do automatically. 🙂 