### PR TITLE
Update gds-sso and replace deprecated auth check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'generic_form_builder', '~> 0.13.0'
 
 # GDS managed gems
 gem 'plek', '~> 2.0.0'
-gem 'gds-sso', '~> 13.2.0'
+gem 'gds-sso', '~> 13.5.0'
 gem 'govuk_admin_template'
 gem "govuk_app_config", "~> 0.2.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 2.0)
-    gds-sso (13.2.0)
+    gds-sso (13.5.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
@@ -325,7 +325,7 @@ DEPENDENCIES
   database_cleaner (~> 1.6.2)
   factory_girl_rails (~> 4.9.0)
   gds-api-adapters (~> 47.9.1)
-  gds-sso (~> 13.2.0)
+  gds-sso (~> 13.5.0)
   generic_form_builder (~> 0.13.0)
   govuk-lint
   govuk_admin_template

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,5 +4,5 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   include GDS::SSO::ControllerMethods
-  before_action :require_signin_permission!
+  before_action :authenticate_user!
 end


### PR DESCRIPTION
The latest version of gds-sso deprecates `require_signin_permission!` because this is now handled by Signon by default.