### PR TITLE
Add rake task for publishing all external links to the publishing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ database.yml.
 
 ### External links
 
-Run `bundle exec rake publish_external_links` to send all external links to rummager.
+Run `bundle exec rake publish_external_links:rummager` to send all external links to rummager, or `bundle exec rake publish_external_links:publishing_api` to send them to the publishing API.
 
 ## Licence
 

--- a/lib/tasks/publish_external_links.rake
+++ b/lib/tasks/publish_external_links.rake
@@ -1,8 +1,18 @@
-desc "Ensure all external links in the database are present in rummager"
-task publish_external_links: :environment do
-  puts "Sending external links to rummager..."
-  RecommendedLink.all.each do |link|
-    puts link.link
-    RummagerLinkSynchronize.put(link)
+desc "Ensure all external links in the database are present in the publishing platform"
+namespace :publish_external_links do
+  task rummager: :environment do
+    puts "Sending external links to rummager..."
+    RecommendedLink.all.each do |link|
+      puts link.link
+      RummagerLinkSynchronize.put(link)
+    end
+  end
+
+  task publishing_api: :environment do
+    puts "Sending external links to the publishing API..."
+    RecommendedLink.all.each do |link|
+      puts link.link
+      ExternalContentPublisher.publish(link)
+    end
   end
 end


### PR DESCRIPTION
This will let us populate the publishing API with all external links, so that we can update rummager from the publishing API rather than from individual publishing apps.

https://trello.com/c/rOplZU0E/524-publish-all-existing-external-links-to-the-publishing-api