### PR TITLE
Downgrade unicorn to fix inconsistent dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '5.1.4'
 
-gem 'unicorn', '~> 5.4.0'
+gem 'unicorn', '~> 5.3.1'
 gem 'mysql2', '~> 0.4.5'
 gem 'sass-rails', '~> 5.0.6'
 gem 'uglifier', '~> 3.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,7 +311,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
-    unicorn (5.4.0)
+    unicorn (5.3.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     warden (1.2.7)
@@ -350,7 +350,7 @@ DEPENDENCIES
   rspec-rails (~> 3.7.2)
   sass-rails (~> 5.0.6)
   uglifier (~> 3.0.4)
-  unicorn (~> 5.4.0)
+  unicorn (~> 5.3.1)
   webmock (~> 3.1.1)
 
 BUNDLED WITH


### PR DESCRIPTION
Downgrade unicorn from 5.4.0 to 5.3.1, which is the latest version compatible with govuk_app_config. These gems were upgraded by dependabot in parallel, and it did not detect the conflict.

I'll report the issue to dependabot since it normally spots dependency conflicts. It might not have detected this one because unicorn was not a dependency of the previous version of govuk_app_config.