### PR TITLE
Update govuk_app_config gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'generic_form_builder', '~> 0.13.0'
 gem 'plek', '~> 2.0.0'
 gem 'gds-sso', '~> 13.5.0'
 gem 'govuk_admin_template'
-gem "govuk_app_config", "~> 1.1.0"
+gem "govuk_app_config", "~> 1.2.0"
 
 gem 'gds-api-adapters', '~> 50.8.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,11 +128,11 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.3.1)
       rails (>= 3.2.0)
-    govuk_app_config (1.1.0)
+    govuk_app_config (1.2.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
-      unicorn (~> 5.3.1)
+      unicorn (~> 5.4.0)
     hashdiff (0.3.7)
     hashie (3.5.6)
     http-cookie (1.0.3)
@@ -243,7 +243,8 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    request_store (1.3.2)
+    request_store (1.4.0)
+      rack (>= 1.4)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -341,7 +342,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6.0)
   govuk-lint
   govuk_admin_template
-  govuk_app_config (~> 1.1.0)
+  govuk_app_config (~> 1.2.0)
   mysql2 (~> 0.4.5)
   plek (~> 2.0.0)
   pry-byebug


### PR DESCRIPTION
This fixes the inconsistency in the Gemfile between unicorn 5.4.0 and the old version of govuk_app_config, which depended on unicorn 5.3.