### PR TITLE
Explicitly use external URLs for Signon

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
 <% end %>
 
 <% content_for :navbar_right do %>
-  <%= link_to current_user.name, Plek.current.find('signon') %>
+  <%= link_to current_user.name, Plek.new.external_url_for('signon') %>
   &bull; <%= link_to 'Sign out', '/auth/gds/sign_out' %>
 <% end %>
 

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -2,5 +2,5 @@ GDS::SSO.config do |config|
   config.user_model     = 'User'
   config.oauth_id       = ENV['OAUTH_ID']
   config.oauth_secret   = ENV['OAUTH_SECRET']
-  config.oauth_root_url = Plek.current.find('signon')
+  config.oauth_root_url = Plek.new.external_url_for('signon')
 end


### PR DESCRIPTION
With the new external_url_for method in Plek.