### PR TITLE
Travel advice best bets importer

### DIFF
--- a/lib/tasks/import_travel_advice_best_bets.rake
+++ b/lib/tasks/import_travel_advice_best_bets.rake
@@ -3,15 +3,16 @@ require "travel_advice_bets_importer"
 
 namespace :travel_advice do
   desc "Imports travel advice best bets into rummager from csv data."
-  task :import_best_bets, [:data_path, :user_name] => :environment do |t, args|
+  task :import_best_bets, %i[data_path user_name] => :environment do |_, args|
     data = CSV.read(args[:data_path])
     user = User.find_by(name: args[:user_name])
     raise "Search admin user name is required" unless user
 
     puts "Processing #{data.size} rows."
 
-    processed = TravelAdviceBetsImporter.new(data, user).import
+    importer = TravelAdviceBetsImporter.new(data, user)
+    importer.import
 
-    puts "Imported #{processed} best bets."
+    puts "Imported #{importer.count} best bets."
   end
 end

--- a/lib/tasks/import_travel_advice_best_bets.rake
+++ b/lib/tasks/import_travel_advice_best_bets.rake
@@ -1,0 +1,17 @@
+require "csv"
+require "travel_advice_bets_importer"
+
+namespace :travel_advice do
+  desc "Imports travel advice best bets into rummager from csv data."
+  task :import_best_bets, [:data_path, :user_name] => :environment do |t, args|
+    data = CSV.read(args[:data_path])
+    user = User.find_by(name: args[:user_name])
+    raise "Search admin user name is required" unless user
+
+    puts "Processing #{data.size} rows."
+
+    processed = TravelAdviceBetsImporter.new(data, user).import
+
+    puts "Imported #{processed} best bets."
+  end
+end

--- a/lib/travel_advice_bets_importer.rb
+++ b/lib/travel_advice_bets_importer.rb
@@ -1,0 +1,74 @@
+class TravelAdviceBetsImporter
+  attr_reader :data, :logger
+
+  # @param data [Array] array of arrays.
+  # @param user [User] search admin user.
+  #
+  def initialize(data, user, logger = STDOUT)
+    @data = data
+    @user = user
+    @logger = logger
+  end
+
+  def import
+    count = 0
+
+    data.each do |term, link|
+      next unless link =~ /^\/world\//
+
+      query = Query.find_or_create_by(query: term) { |q| q.match_type = "exact" }
+
+      travel_advice_bet = create_travel_advice_bet(query, link)
+      if travel_advice_bet
+        RummagerSaver.new(travel_advice_bet).save
+        count += 1
+        logger.puts "Saved best bet '#{term}' : '#{travel_advice_bet.link}' to Rummager."
+      end
+
+      help_page_bet = create_travel_advice_help_page_bet(query, link)
+      if help_page_bet
+        RummagerSaver.new(help_page_bet).save
+        count += 1
+        logger.puts "Saved best bet '#{term}' : '#{help_page_bet.link}' to Rummager."
+      end
+    end
+
+    count
+  end
+
+private
+
+  attr_reader :user
+
+  def create_travel_advice_bet(query, link)
+    ta_path = travel_advice_path(link)
+    return if Bet.find_by(link: ta_path)
+
+    Bet.create(
+      comment: "Created by bets importer.",
+      is_best: true,
+      link: ta_path,
+      query_id: query.id,
+      user_id: user.id,
+      position: 1,
+    )
+  end
+
+  def create_travel_advice_help_page_bet(query, link)
+    return if Bet.find_by(link: link)
+
+    Bet.create(
+      comment: "Created by bets importer.",
+      is_best: true,
+      link: link,
+      query_id: query.id,
+      user_id: user.id,
+      position: 2,
+    )
+  end
+
+  def travel_advice_path(help_page_link)
+    country = help_page_link.split("/").last
+    "/foreign-travel-advice/#{country}"
+  end
+end

--- a/lib/travel_advice_bets_importer.rb
+++ b/lib/travel_advice_bets_importer.rb
@@ -1,18 +1,18 @@
 class TravelAdviceBetsImporter
-  attr_reader :data, :logger
+  attr_reader :count, :data
 
-  # @param data [Array] array of arrays.
+  # @param data [Array] array of arrays eg. [[term_a, link_a],[term_b, link_b]].
   # @param user [User] search admin user.
+  # @param logger [IO] stream for logging.
   #
   def initialize(data, user, logger = STDOUT)
+    @count = 0
     @data = data
     @user = user
     @logger = logger
   end
 
   def import
-    count = 0
-
     data.each do |term, link|
       next unless link =~ /^\/world\//
 
@@ -20,25 +20,19 @@ class TravelAdviceBetsImporter
 
       travel_advice_bet = create_travel_advice_bet(query, link)
       if travel_advice_bet
-        RummagerSaver.new(travel_advice_bet).save
-        count += 1
-        logger.puts "Saved best bet '#{term}' : '#{travel_advice_bet.link}' to Rummager."
+        success(travel_advice_bet) if RummagerSaver.new(travel_advice_bet).save
       end
 
       help_page_bet = create_travel_advice_help_page_bet(query, link)
       if help_page_bet
-        RummagerSaver.new(help_page_bet).save
-        count += 1
-        logger.puts "Saved best bet '#{term}' : '#{help_page_bet.link}' to Rummager."
+        success(help_page_bet) if RummagerSaver.new(help_page_bet).save
       end
     end
-
-    count
   end
 
 private
 
-  attr_reader :user
+  attr_reader :logger, :user
 
   def create_travel_advice_bet(query, link)
     ta_path = travel_advice_path(link)
@@ -70,5 +64,10 @@ private
   def travel_advice_path(help_page_link)
     country = help_page_link.split("/").last
     "/foreign-travel-advice/#{country}"
+  end
+
+  def success(bet)
+    @count += 1
+    logger.puts "Saved best bet '#{bet.query.query}': '#{bet.link}' (pos: #{bet.position}) to Rummager."
   end
 end

--- a/lib/travel_advice_bets_importer.rb
+++ b/lib/travel_advice_bets_importer.rb
@@ -18,12 +18,12 @@ class TravelAdviceBetsImporter
 
       query = Query.find_or_create_by(query: term) { |q| q.match_type = "exact" }
 
-      travel_advice_bet = create_travel_advice_bet(query, link)
+      travel_advice_bet = create_bet(query, travel_advice_path(link), 1)
       if travel_advice_bet
         success(travel_advice_bet) if RummagerSaver.new(travel_advice_bet).save
       end
 
-      help_page_bet = create_travel_advice_help_page_bet(query, link)
+      help_page_bet = create_bet(query, link, 2)
       if help_page_bet
         success(help_page_bet) if RummagerSaver.new(help_page_bet).save
       end
@@ -34,21 +34,7 @@ private
 
   attr_reader :logger, :user
 
-  def create_travel_advice_bet(query, link)
-    ta_path = travel_advice_path(link)
-    return if Bet.find_by(link: ta_path)
-
-    Bet.create(
-      comment: "Created by bets importer.",
-      is_best: true,
-      link: ta_path,
-      query_id: query.id,
-      user_id: user.id,
-      position: 1,
-    )
-  end
-
-  def create_travel_advice_help_page_bet(query, link)
+  def create_bet(query, link, position)
     return if Bet.find_by(link: link)
 
     Bet.create(
@@ -57,7 +43,7 @@ private
       link: link,
       query_id: query.id,
       user_id: user.id,
-      position: 2,
+      position: position,
     )
   end
 

--- a/lib/travel_advice_bets_importer.rb
+++ b/lib/travel_advice_bets_importer.rb
@@ -35,7 +35,7 @@ private
   attr_reader :logger, :user
 
   def create_bet(query, link, position)
-    return if Bet.find_by(link: link)
+    return if Bet.find_by(link: link, query: query)
 
     Bet.create(
       comment: "Created by bets importer.",

--- a/spec/lib/travel_advice_bets_importer_spec.rb
+++ b/spec/lib/travel_advice_bets_importer_spec.rb
@@ -86,5 +86,18 @@ RSpec.describe TravelAdviceBetsImporter do
         expect(instance.count).to eq(5)
       end
     end
+
+    context "with existing non-conflicting bets" do
+      let(:query) { create(:query, query: "Spain") }
+      let!(:bet) { create(:bet, link: "/world/spain", query: query, position: 2) }
+      before { csv_data.push(%w(Espana /world/spain)) }
+
+      it "creates a best bet" do
+        instance.import
+        expect(Query.where(query: "Spain").count).to eq(1)
+        expect(Query.where(query: "Espana").count).to eq(1)
+        expect(Bet.where(link: "/world/spain").count).to eq(2)
+      end
+    end
   end
 end

--- a/spec/lib/travel_advice_bets_importer_spec.rb
+++ b/spec/lib/travel_advice_bets_importer_spec.rb
@@ -1,0 +1,81 @@
+require "spec_helper"
+require "travel_advice_bets_importer"
+
+RSpec.describe TravelAdviceBetsImporter do
+  let(:csv_data) {
+    [
+      ["Angola", "/world/angola"],
+      ["Belgium", "/world/belgium"],
+      ["Spain", "/world/spain"]
+    ]
+  }
+  let(:logger) { double(:logger) }
+  let(:rummager_saver) { double(:rummager_saver) }
+  let(:user) { create(:user) }
+
+  subject(:instance) { described_class.new(csv_data, user, logger) }
+
+  describe "import" do
+    before do
+      allow(RummagerSaver).to receive(:new)
+        .and_return(rummager_saver)
+      allow(rummager_saver).to receive(:save)
+      allow(logger).to receive(:puts)
+    end
+
+    it "creates queries" do
+      expect { instance.import }.to change(Query, :count).by(3)
+    end
+
+    it "creates bets" do
+      expect { instance.import }.to change(Bet, :count).by(6)
+      expect(Bet.all.map(&:link)).to eq([
+        "/foreign-travel-advice/angola",
+        "/world/angola",
+        "/foreign-travel-advice/belgium",
+        "/world/belgium",
+        "/foreign-travel-advice/spain",
+        "/world/spain"
+      ])
+    end
+
+    it "saves bets in Rummager" do
+      instance.import
+      expect(rummager_saver).to have_received(:save).exactly(6).times
+      expect(RummagerSaver).to have_received(:new).with(Bet.first)
+      expect(RummagerSaver).to have_received(:new).with(Bet.last)
+    end
+
+    it "logs stuff" do
+      instance.import
+      expect(logger).to have_received(:puts).with("Saved best bet 'Spain' : '/foreign-travel-advice/spain' to Rummager.")
+      expect(logger).to have_received(:puts).with("Saved best bet 'Spain' : '/world/spain' to Rummager.")
+    end
+
+    context "with valid and invalid data" do
+      before do
+        csv_data.push(["Narnia", "narnia"])
+      end
+
+      it "skips invalid data" do
+        expect(Query.find_by(query: "Narnia")).to be_nil
+        expect(Bet.find_by(link: "narnia")).to be_nil
+      end
+    end
+
+    context "with existing, conflicting bets" do
+      let(:query) { create(:query, query: "Spain") }
+      let!(:bet) { create(:bet, link: "/world/spain", query: query, position: 2) }
+
+      it "doesn't create duplicates" do
+        expect { instance.import }.to change(Bet, :count).by(5)
+        expect(Bet.where(link: "/world/spain").count).to eq(1)
+      end
+
+      it "doesn't save duplicates in Rummager" do
+        instance.import
+        expect(rummager_saver).to have_received(:save).exactly(5).times
+      end
+    end
+  end
+end

--- a/spec/lib/travel_advice_bets_importer_spec.rb
+++ b/spec/lib/travel_advice_bets_importer_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe TravelAdviceBetsImporter do
       allow(RummagerSaver).to receive(:new)
         .and_return(rummager_saver)
       allow(rummager_saver).to receive(:save)
+        .and_return(true)
       allow(logger).to receive(:puts)
     end
 
@@ -48,13 +49,20 @@ RSpec.describe TravelAdviceBetsImporter do
 
     it "logs stuff" do
       instance.import
-      expect(logger).to have_received(:puts).with("Saved best bet 'Spain' : '/foreign-travel-advice/spain' to Rummager.")
-      expect(logger).to have_received(:puts).with("Saved best bet 'Spain' : '/world/spain' to Rummager.")
+      expect(logger).to have_received(:puts)
+        .with("Saved best bet 'Spain': '/foreign-travel-advice/spain' (pos: 1) to Rummager.")
+      expect(logger).to have_received(:puts)
+        .with("Saved best bet 'Spain': '/world/spain' (pos: 2) to Rummager.")
+    end
+
+    it "increments an internal count of successful saves" do
+      instance.import
+      expect(instance.count).to eq(6)
     end
 
     context "with valid and invalid data" do
       before do
-        csv_data.push(["Narnia", "narnia"])
+        csv_data.push(%w(Narnia narnia))
       end
 
       it "skips invalid data" do
@@ -75,6 +83,7 @@ RSpec.describe TravelAdviceBetsImporter do
       it "doesn't save duplicates in Rummager" do
         instance.import
         expect(rummager_saver).to have_received(:save).exactly(5).times
+        expect(instance.count).to eq(5)
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/SXcOczHM/63-2-bulk-import-foreign-travel-advice-best-bets

Adds a rake task and importer to create best bets for travel advice pages and their associated help & services pages.
Ranks the travel advice bet above the help page bet and sends these to Rummager.

Expects data in the format:

term | help page path
-- | --
united states of america | /world/usa
new york | /world/usa
us | /world/usa
Zambia | /world/zambia
myanmar | /world/burma
Bali | /world/indonesia
America | /world/usa
columbia | /world/colombia
united states | /world/usa
holland | /world/netherlands
jamaca | /world/jamaica


