### PR TITLE
Change Plek(rummager) to Plek(search)

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,11 +28,11 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
   config.before(:each) do
-    # rummager URLs are of the form: http://rummager.dev.gov.uk/mainstream/document/http://test.dev.gov.uk
+    # search URLs are of the form: http://search.dev.gov.uk/mainstream/document/http://test.dev.gov.uk
     # The part after /document/ is optional depending on the request type
-    rummager_url_regex = %r{#{Plek.find('rummager')}/.+/.+(/.*)?}
-    stub_request(:post, rummager_url_regex)
-    stub_request(:delete, rummager_url_regex)
+    search_url_regex = %r{#{Plek.find('search')}/.+/.+(/.*)?}
+    stub_request(:post, search_url_regex)
+    stub_request(:delete, search_url_regex)
   end
 
   config.before(:each, type: 'controller') do


### PR DESCRIPTION
For the migration to search-api we're going to re-target the 'search'
alias to search-api.

---

[Trello card](https://trello.com/c/yrq9hZmU/77-point-the-search-alias-to-search-api-if-rummager-is-disabled)