### PR TITLE
Remove edited Queries from ES before re-adding them

### DIFF
--- a/app/models/bet.rb
+++ b/app/models/bet.rb
@@ -21,4 +21,12 @@ class Bet < ApplicationRecord
   def self.worst
     where.not(is_best: true)
   end
+
+  def is_query?
+    false
+  end
+
+  def query_object
+    self.query
+  end
 end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -18,6 +18,14 @@ class Query < ApplicationRecord
     "#{query} (#{match_type})"
   end
 
+  def is_query?
+    true
+  end
+
+  def query_object
+    self
+  end
+
   def self.to_csv(*_args)
     CSV.generate do |csv|
       csv << ['query', 'match_type', 'link', 'best/worst', 'comment']

--- a/app/services/rummager_saver.rb
+++ b/app/services/rummager_saver.rb
@@ -1,4 +1,6 @@
 class RummagerSaver
+  delegate :is_query?, :query_object, to: :@object
+
   def initialize(object)
     @object = object
   end
@@ -6,7 +8,7 @@ class RummagerSaver
   def save
     ActiveRecord::Base.transaction do
       @object.save!
-      update_elasticsearch(query, :create)
+      update_elasticsearch(query_object, :create)
     end
     true
   rescue ActiveRecord::ActiveRecordError, GdsApi::HTTPInternalServerError, GdsApi::HTTPClientError
@@ -15,9 +17,9 @@ class RummagerSaver
 
   def update_attributes(params)
     ActiveRecord::Base.transaction do
-      update_elasticsearch(query, :delete) if @object.is_a?(Query) && query.bets.any? # prevent old queries still being indexed in search
+      update_elasticsearch(query_object, :delete) if is_query? && query_object.bets.any? # prevent old queries still being indexed in search
       @object.update_attributes!(params)
-      update_elasticsearch(query, :update)
+      update_elasticsearch(query_object, :update)
     end
     true
   rescue ActiveRecord::ActiveRecordError, GdsApi::HTTPInternalServerError, GdsApi::HTTPClientError
@@ -28,7 +30,7 @@ class RummagerSaver
     ActiveRecord::Base.transaction do
       @object.destroy!
       begin
-        update_elasticsearch(query, action)
+        update_elasticsearch(query_object, action)
       rescue GdsApi::HTTPNotFound # rubocop:disable Lint/HandleExceptions
       end
     end
@@ -40,16 +42,12 @@ class RummagerSaver
 private
 
   def update_elasticsearch(query, action)
-    if action != :delete && query.bets.any?
-      es_doc = ElasticSearchBet.new(query)
+    if action != :delete && query_object.bets.any?
+      es_doc = ElasticSearchBet.new(query_object)
       Services.rummager.add_document(es_doc.id, es_doc.body, 'metasearch')
     elsif action != :create # so hitting save with no best bets will delete the query
-      es_doc_id = ElasticSearchBetIDGenerator.generate(query.query, query.match_type)
+      es_doc_id = ElasticSearchBetIDGenerator.generate(query_object.query, query_object.match_type)
       Services.rummager.delete_document(URI.escape(es_doc_id), 'metasearch') # rubocop:disable Lint/UriEscapeUnescape
     end
-  end
-
-  def query
-    @object.is_a?(Query) ? @object : @object.query
   end
 end

--- a/app/services/rummager_saver.rb
+++ b/app/services/rummager_saver.rb
@@ -15,6 +15,7 @@ class RummagerSaver
 
   def update_attributes(params)
     ActiveRecord::Base.transaction do
+      update_elasticsearch(query, :delete) if @object.is_a?(Query) && query.bets.any? # prevent old queries still being indexed in search
       @object.update_attributes!(params)
       update_elasticsearch(query, :update)
     end

--- a/spec/controllers/bets_controller_spec.rb
+++ b/spec/controllers/bets_controller_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe BetsController do
   before do
     allow(Services.rummager).to receive(:add_document)
+    allow(Services.rummager).to receive(:delete_document)
   end
 
   let(:query) { create(:query) }
@@ -67,6 +68,12 @@ describe BetsController do
       put :update, params: { id: bet.id, bet: bet_params }
 
       expect(Services.rummager).to have_received(:add_document)
+    end
+
+    it "does not notify the world to forget the query" do
+      put :update, params: { id: bet.id, bet: bet_params }
+
+      expect(Services.rummager).not_to have_received(:delete_document)
     end
 
     it "redirects to the query show when update is successful" do

--- a/spec/controllers/queries_controller_spec.rb
+++ b/spec/controllers/queries_controller_spec.rb
@@ -37,7 +37,7 @@ describe QueriesController do
         expect(response).to redirect_to(query_path(Query.last))
       end
 
-      it "does not notifies the world of the new query - needs to wait for bets" do
+      it "does not notify the world of the new query - needs to wait for bets" do
         post :create, params: { query: query_params }
         expect(Services.rummager).not_to have_received(:add_document)
       end
@@ -96,9 +96,16 @@ describe QueriesController do
           create(:bet, query: query)
         end
 
+        it "notifies the world to forget the previous query" do
+          update_query
+          expect(Services.rummager).to have_received(:delete_document)
+            .with("#{query.query}-#{query.match_type}", any_args)
+        end
+
         it "notifies the world of the new query" do
           update_query
           expect(Services.rummager).to have_received(:add_document)
+            .with("#{query_params[:query]}-#{query_params[:match_type]}", any_args)
         end
       end
 

--- a/spec/models/best_bet_spec.rb
+++ b/spec/models/best_bet_spec.rb
@@ -3,12 +3,13 @@ require 'spec_helper'
 describe Bet do
   context 'for a best bet' do
     before do
+      @query = create(:query)
       @best_bet_attributes = {
         comment: "Boost the most common job page to the top",
         is_best: true,
         link: "/jobsearch",
         position: 1,
-        query_id: 1,
+        query_id: @query.id,
         user_id: 1,
       }
     end
@@ -66,6 +67,22 @@ describe Bet do
 
       expect(best_bet).to_not be_valid
       expect(best_bet.errors).to have_key(:user_id)
+    end
+
+    describe "#is_query?" do
+      it "should return false" do
+        best_bet = Bet.new(@best_bet_attributes)
+
+        expect(best_bet.is_query?).to eq false
+      end
+    end
+
+    describe "#query_object" do
+      it "should return its parent query" do
+        best_bet = Bet.new(@best_bet_attributes)
+
+        expect(best_bet.query_object).to eq @query
+      end
     end
   end
 

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -1,6 +1,20 @@
 require 'spec_helper'
 
 describe Query do
+  describe "#is_query?" do
+    it "should return true" do
+      query = create(:query)
+      expect(query.is_query?).to eq true
+    end
+  end
+
+  describe "#query_object" do
+    it "should return itself" do
+      query = create(:query)
+      expect(query.query_object).to eq query
+    end
+  end
+
   describe '#sorted_best_bets' do
     it "sorts the best bets by position" do
       query = create(:query)

--- a/spec/services/rummager_saver_spec.rb
+++ b/spec/services/rummager_saver_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe RummagerSaver do
+  let(:query)          { create(:query) }
+  let(:rummager_saver) { described_class.new(query) }
+
+  describe "#destroy" do
+    context "when passed an unrecognised action" do
+      it "raises a custom InvalidAction Error" do
+        error_message = "invalid_action not one of: :update, :create, :update_bets, : delete"
+
+        expect { rummager_saver.destroy(action: :invalid_action) }.to raise_error(
+          RummagerSaver::InvalidAction, error_message
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Editing a Query results in "orphaned" Bets in Rummager, associated with the
previous iteration of the Query that Search-Admin no longer recognises.

This commit removes the previous iteration from Rummager before sending the
updated Query. This ensures that Search-Admin and Rummager remain in sync regarding
search queries and bets.