### PR TITLE
Use all-content finder URL for preview iframe

### DIFF
--- a/app/services/search_url.rb
+++ b/app/services/search_url.rb
@@ -3,6 +3,6 @@ class SearchUrl
     base_url = Plek.current.website_root
     search_term = CGI::escape(search_term)
     random = SecureRandom.hex(10)
-    "#{base_url}/search?q=#{search_term}&debug_score=1&cachebust=#{random}"
+    "#{base_url}/search/all?keywords=#{search_term}&order=relevance&debug_score=1&cachebust=#{random}"
   end
 end

--- a/features/step_definitions/query_steps.rb
+++ b/features/step_definitions/query_steps.rb
@@ -28,5 +28,5 @@ end
 
 Then(/^I should see the queries search results on the page$/) do
   expect(page).to have_selector("iframe")
-  expect(find("iframe")[:src]).to include "gov.uk/search?q=jobs"
+  expect(find("iframe")[:src]).to include "gov.uk/search/all?keywords=jobs"
 end

--- a/features/step_definitions/recommended_links_steps.rb
+++ b/features/step_definitions/recommended_links_steps.rb
@@ -55,5 +55,5 @@ end
 
 Then(/^I should see the external links search results on the page$/) do
   expect(page).to have_selector("iframe")
-  expect(find("iframe")[:src]).to include "gov.uk/search?q=Tax+online"
+  expect(find("iframe")[:src]).to include "gov.uk/search/all?keywords=Tax+online"
 end


### PR DESCRIPTION
/search?q=... does redirect to /search/all?keywords=..., but it
doesn't preserve the debug_score or cachebust parameters.

---

[Trello card](https://trello.com/c/F9IlW4Ml/1049-search-admin-best-bets-iframe-preview-still-uses-old-search-url-and-doesnt-cachebust)