### PR TITLE
Fix accidentally quadratic table processing

### DIFF
--- a/app/assets/javascripts/filter-table.js
+++ b/app/assets/javascripts/filter-table.js
@@ -2,19 +2,17 @@ var combineQueryRows = function() {
   var $queriesTable = $('.queries-table')
 
   if ($queriesTable) {
-    $queriesTable.find('tr').each(function(index) {
-       var rows = $queriesTable.find("tr");
-        for(var i = 0; i <= rows.length; i++) {
-          var $currentRow = $(rows[i])
-          var currentRowQuery = $currentRow.find("td").first().text()
-          var $nextRow = $(rows[i+1])
-          var nextRowQuery = $nextRow.find("td").first().text()
-          if (currentRowQuery.toLowerCase().trim() === nextRowQuery.toLowerCase().trim()) {
-            $nextRow.addClass('govuk-table__row--group')
-            $currentRow.addClass('govuk-table__row--group')
-          }
-        }
-    });
+    var rows = $queriesTable.find("tr");
+    for(var i = 0; i <= rows.length; i++) {
+      var $currentRow = $(rows[i])
+      var currentRowQuery = $currentRow.find("td").first().text()
+      var $nextRow = $(rows[i+1])
+      var nextRowQuery = $nextRow.find("td").first().text()
+      if (currentRowQuery.toLowerCase().trim() === nextRowQuery.toLowerCase().trim()) {
+        $nextRow.addClass('govuk-table__row--group')
+        $currentRow.addClass('govuk-table__row--group')
+      }
+    }
   }
 };
 combineQueryRows();


### PR DESCRIPTION
The outer `each` doesn't do anything, and there are a lot of rows.

Down from over 30s to fully load the page to 3s.