### PR TITLE
Delete 3-month-old expired or disabled bets

### DIFF
--- a/app/models/bet.rb
+++ b/app/models/bet.rb
@@ -6,6 +6,8 @@ class Bet < ApplicationRecord
   belongs_to :user
   belongs_to :query
 
+  scope :best,        -> { where(is_best: true) }
+  scope :worst,       -> { where(is_best: false) }
   scope :impermanent, -> { where(permanent: false) }
 
   attr_accessor :is_worst
@@ -74,14 +76,6 @@ class Bet < ApplicationRecord
     else
       "Expired"
     end
-  end
-
-  def self.best
-    where(is_best: true)
-  end
-
-  def self.worst
-    where.not(is_best: true)
   end
 
   def is_query?

--- a/app/models/bet.rb
+++ b/app/models/bet.rb
@@ -6,6 +6,8 @@ class Bet < ApplicationRecord
   belongs_to :user
   belongs_to :query
 
+  scope :impermanent, -> { where(permanent: false) }
+
   attr_accessor :is_worst
   validates :expiration_date, bet_date: true
   validates :query_id, :user_id, presence: true

--- a/app/workers/delete_old_bets_worker.rb
+++ b/app/workers/delete_old_bets_worker.rb
@@ -1,0 +1,37 @@
+class DeleteOldBetsWorker
+  # All expired bets older than this, or all disabled bets last
+  # updated longer ago than this, are deleted
+  OLD_BET_THRESHOLD = 90.days
+
+  include Sidekiq::Worker
+
+  def perform
+    queries = old_expired_bets.map(&:query_id).uniq + old_disabled_bets.map(&:query_id).uniq
+
+    old_expired_bets.delete_all
+    old_disabled_bets.delete_all
+
+    # remove empty queries from search-api to avoid cruft in the index
+    queries.each do |qid|
+      q = Query.find(qid)
+      SearchApiSaver.new(q).destroy(action: :delete) if q.bets.empty?
+    end
+  end
+
+private
+
+  def old_expired_bets
+    Bet.where(
+      "NOT permanent AND expiration_date IS NOT NULL AND expiration_date <= ?",
+      OLD_BET_THRESHOLD.ago,
+    )
+  end
+
+  def old_disabled_bets
+    Bet.where(
+      "NOT permanent AND expiration_date IS NULL AND ((updated_at IS NULL AND created_at <= ?) OR (updated_at IS NOT NULL AND updated_at <= ?))",
+      OLD_BET_THRESHOLD.ago,
+      OLD_BET_THRESHOLD.ago,
+    )
+  end
+end

--- a/app/workers/delete_old_bets_worker.rb
+++ b/app/workers/delete_old_bets_worker.rb
@@ -21,15 +21,15 @@ class DeleteOldBetsWorker
 private
 
   def old_expired_bets
-    Bet.where(
-      "NOT permanent AND expiration_date IS NOT NULL AND expiration_date <= ?",
+    Bet.impermanent.where(
+      "expiration_date IS NOT NULL AND expiration_date <= ?",
       OLD_BET_THRESHOLD.ago,
     )
   end
 
   def old_disabled_bets
-    Bet.where(
-      "NOT permanent AND expiration_date IS NULL AND ((updated_at IS NULL AND created_at <= ?) OR (updated_at IS NOT NULL AND updated_at <= ?))",
+    Bet.impermanent.where(
+      "expiration_date IS NULL AND ((updated_at IS NULL AND created_at <= ?) OR (updated_at IS NOT NULL AND updated_at <= ?))",
       OLD_BET_THRESHOLD.ago,
       OLD_BET_THRESHOLD.ago,
     )

--- a/app/workers/expired_bet_worker.rb
+++ b/app/workers/expired_bet_worker.rb
@@ -13,7 +13,7 @@ private
   # 90 minutes - this is to reduce the chance of something being
   # missed due to jitter in job start time.
   def recently_expired_bets
-    Bet.where(
+    Bet.impermanent.where(
       "expiration_date IS NOT NULL AND expiration_date >= ? AND expiration_date <= ?",
       90.minutes.ago,
       Time.zone.now,

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,3 +4,6 @@
   expired_bet_worker:
     every: '1h'
     class: ExpiredBetWorker
+  delete_old_bets_worker:
+    cron: '0 0 1 * * Europe/London'
+    class: DeleteOldBetsWorker


### PR DESCRIPTION
We might want to bring a bet back after it expires, but if it's been
left inactive for so long the chances of that are pretty slim.

Deleting the bets without deleting them from search-api is fine, as
they'll already have been removed from search-api by this point.

At the same time, delete empty queries too.  This removes cruft in the
search-admin UI and in the metasearch index.

---

I changed `best` and `worst` into scopes while I was touching this code.  It makes sense to follow ActiveRecord patterns for that sort of thing rather than define our own class methods.

---

[Trello card](https://trello.com/c/k23Gm7ZO/1443-inactive-bets-are-automatically-deleted-after-3-months)