### PR TITLE
Send out an email about expiring best bets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "bootsnap", "~> 1.4"
 gem "generic_form_builder", "~> 0.13.1"
 gem "mysql2", "~> 0.4.5"
 gem "sass-rails", "~> 5.1.0"
+gem "sidekiq-scheduler", "~> 3.0"
 gem "uglifier", "~> 4.2.0"
 
 # GDS managed gems
@@ -15,8 +16,8 @@ gem "govuk_admin_template"
 gem "govuk_app_config", "~> 2.1.2"
 gem "govuk_publishing_components", "~> 21.30.0"
 gem "govuk_sidekiq", "~> 3.0"
+gem "mail-notify"
 gem "plek", "~> 3.0.0"
-gem "sidekiq-scheduler", "~> 3.0"
 
 group :test do
   gem "cucumber-rails", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,9 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    mail-notify (1.0.1)
+      actionmailer (>= 5.0, < 6.1)
+      notifications-ruby-client (~> 5.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
@@ -225,6 +228,8 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    notifications-ruby-client (5.1.2)
+      jwt (>= 1.5, < 3)
     null_logger (0.0.1)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
@@ -440,6 +445,7 @@ DEPENDENCIES
   govuk_publishing_components (~> 21.30.0)
   govuk_sidekiq (~> 3.0)
   listen (~> 3.2)
+  mail-notify
   mysql2 (~> 0.4.5)
   plek (~> 3.0.0)
   pry-byebug

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,17 @@
+class ApplicationMailer < Mail::Notify::Mailer
+  default from: Proc.new { no_reply_email_address }
+
+  def no_reply_email_address
+    name = "GOV.UK publishing"
+    if GovukAdminTemplate.environment_label !~ /production/i
+      name.prepend("[GOV.UK #{GovukAdminTemplate.environment_label}] ")
+    end
+    address = Mail::Address.new("inside-government@digital.cabinet-office.gov.uk")
+    address.display_name = name
+    address.format
+  end
+
+  def template_id
+    @template_id ||= ENV.fetch("GOVUK_NOTIFY_TEMPLATE_ID", "fake-test-template-id")
+  end
+end

--- a/app/mailers/bets_mailer.rb
+++ b/app/mailers/bets_mailer.rb
@@ -1,0 +1,15 @@
+class BetsMailer < ApplicationMailer
+  def expiring_bets_list(address, bets)
+    @when = bets.first.expiration_date
+    @grouped_bets = bets.each_with_object({}) do |bet, grouped|
+      grouped[bet.query.display_name] ||= []
+      grouped[bet.query.display_name] << bet.link
+    end
+
+    view_mail(
+      template_id,
+      to: address,
+      subject: "Best and worst bets expiring on #{@when.strftime('%d %b %Y')}",
+    )
+  end
+end

--- a/app/views/bets_mailer/expiring_bets_list.text.erb
+++ b/app/views/bets_mailer/expiring_bets_list.text.erb
@@ -1,0 +1,6 @@
+Hello,
+
+The following best and worst bets expire on <%= @when.strftime('%d %b %Y') %>.
+<% @grouped_bets.keys.sort.each do |query| %><% @grouped_bets[query].sort.each do |bet| %>
+- <%= query %>: <%= bet %>
+<% end %><% end %>

--- a/app/workers/notify_expiring_bets_worker.rb
+++ b/app/workers/notify_expiring_bets_worker.rb
@@ -1,0 +1,36 @@
+class NotifyExpiringBetsWorker
+  THRESHOLD = 7.days
+
+  include Sidekiq::Worker
+
+  def perform
+    unless soon_to_expire_bets.empty?
+      addresses.each do |address|
+        NotificationsMailer.expiring_bets_list(address, soon_to_expire_bets).deliver_now
+      end
+    end
+
+    # also notify bet creators (if they're not in the 'addresses'
+    # list).
+    grouped_bets = soon_to_expire_bets.each_with_object({}) do |bet, grouped|
+      address = bet.user.email
+      next if addresses.include? address
+
+      grouped[address] ||= []
+      grouped[address] << bet
+    end
+    grouped_bets.each do |address, bets|
+      NotificationsMailer.expiring_bets_list(address, bets).deliver_now
+    end
+  end
+
+private
+
+  def addresses
+    ENV.fetch("EXPIRING_BETS_MAILING_LIST", "").split(",")
+  end
+
+  def soon_to_expire_bets
+    @soon_to_expire_bets ||= Bet.impermanent.where(expiration_date: DateTime.now.beginning_of_day + THRESHOLD)
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,8 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :file
+
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,6 +59,11 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :notify
+  config.action_mailer.notify_settings = {
+    api_key: Rails.application.secrets.notify_api_key,
+  }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,3 +23,4 @@ test:
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  notify_api_key: <%= ENV["GOVUK_NOTIFY_API_KEY"] %>

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,3 +7,6 @@
   delete_old_bets_worker:
     cron: '0 0 1 * * Europe/London'
     class: DeleteOldBetsWorker
+  notify_expiring_bets_worker:
+    cron: '0 7 * * * Europe/London'
+    class: NotifyExpiringBetsWorker

--- a/spec/mailers/bets_mailer_spec.rb
+++ b/spec/mailers/bets_mailer_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe BetsMailer, type: :mailer do
+  describe "expiring_bets_list" do
+    let(:address) { "example@publishing.service.gov.uk" }
+
+    let(:expires) { Time.zone.now }
+
+    let(:bets) do
+      test_stemmed = create(:query, query: "test",  match_type: "stemmed")
+      test_exact   = create(:query, query: "test",  match_type: "exact")
+      bread_exact  = create(:query, query: "bread", match_type: "exact")
+      bet1 = create(:bet, query: test_stemmed, position: 2, link: "/foo", expiration_date: expires)
+      bet2 = create(:bet, query: test_stemmed, position: 1, link: "/bar", expiration_date: expires)
+      bet3 = create(:bet, query: test_exact,   position: 1, link: "/baz", expiration_date: expires)
+      bet4 = create(:bet, query: bread_exact,  position: 1, link: "/bat", expiration_date: expires)
+
+      [bet1, bet4, bet3, bet2]
+    end
+
+    let(:mail) { described_class.expiring_bets_list(address, bets) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Best and worst bets expiring on #{expires.strftime('%d %b %Y')}")
+      expect(mail.to).to eq([address])
+      expect(mail.from).to eq(["inside-government@digital.cabinet-office.gov.uk"])
+    end
+
+    it "renders the body" do
+      puts mail.body.encoded
+      expect(mail.body.encoded).to include("The following best and worst bets expire on #{expires.strftime('%d %b %Y')}.")
+      bets.each do |bet|
+        expect(mail.body.encoded).to include("- #{bet.query.display_name}: #{bet.link}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Largely based on https://github.com/alphagov/specialist-publisher/pull/1593 and https://github.com/alphagov/specialist-publisher/pull/1616

This needs `GOVUK_NOTIFY_API_KEY `, `GOVUK_NOTIFY_TEMPLATE_ID`, and `EXPIRING_BETS_MAILING_LIST` env vars.

The API key is per-app per-environment (I've now got access to create these), the template ID is per-environment (so we can copy it from another app).  So we need to do the equivalent of https://github.com/alphagov/govuk-secrets/pull/913 and https://github.com/alphagov/govuk-puppet/pull/10174.

The mailing list going to be Tara and Andrew.

---

[Trello card](https://trello.com/c/B5c5gLS8/1442-email-notifications-for-search-admin)