### PR TITLE
Delete expired and disabled bets more promptly

### DIFF
--- a/app/models/bet.rb
+++ b/app/models/bet.rb
@@ -8,7 +8,7 @@ class Bet < ApplicationRecord
 
   scope :best,        -> { where(is_best: true) }
   scope :worst,       -> { where(is_best: false) }
-  scope :impermanent, -> { where(permanent: false) }
+  scope :impermanent, -> { where("permanent IS NULL OR NOT permanent") }
 
   attr_accessor :is_worst
   validates :expiration_date, bet_date: true

--- a/app/workers/delete_old_bets_worker.rb
+++ b/app/workers/delete_old_bets_worker.rb
@@ -1,7 +1,7 @@
 class DeleteOldBetsWorker
   # All expired bets older than this, or all disabled bets last
   # updated longer ago than this, are deleted
-  OLD_BET_THRESHOLD = 90.days
+  OLD_BET_THRESHOLD = 30.days
 
   include Sidekiq::Worker
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,7 +5,7 @@
     every: '1h'
     class: ExpiredBetWorker
   delete_old_bets_worker:
-    cron: '0 0 1 * * Europe/London'
+    cron: '0 5 * * * Europe/London'
     class: DeleteOldBetsWorker
   notify_expiring_bets_worker:
     cron: '0 7 * * * Europe/London'


### PR DESCRIPTION
There was a small bug with the handling of disabled bets (but not auto-expired bets): they get `permanent: nil`, not `permanent: false`, so `Bet.impermanent` in the worker wouldn't match any.  Whoops.

Also, checking a 90-day cutoff every month is not great, as it means that if a bet was disabled 89 days ago on the 1st, it'll stick around for the whole rest of the month!  Reduce that cutoff to 30 days and run the worker daily to avoid them hanging around.