### PR TITLE
Upgrade to Ruby 2.7.1

### DIFF
--- a/app/parsers/bet_params_parser.rb
+++ b/app/parsers/bet_params_parser.rb
@@ -19,7 +19,7 @@ class BetParamsParser
 private
 
   def date_attributes
-    date_complete? ? DateParser.new(date_hash).date : ""
+    date_complete? ? DateParser.new(**date_hash).date : ""
   end
 
   def date_hash

--- a/app/services/search_api_saver.rb
+++ b/app/services/search_api_saver.rb
@@ -67,6 +67,6 @@ private
 
   def remove_from_elasticsearch
     es_doc_id = ElasticSearchBetIDGenerator.generate(query_object.query, query_object.match_type)
-    Services.search_api.delete_document(URI.escape(es_doc_id), "metasearch") # rubocop:disable Lint/UriEscapeUnescape
+    Services.search_api.delete_document(URI.encode_www_form_component(es_doc_id).gsub("+", "%20"), "metasearch")
   end
 end


### PR DESCRIPTION
These are the necessary changes for Ruby 2.7.1

I have left the version at 2.6.6 since there is an automated way to update all apps' Ruby versions at the same time