### PR TITLE
Use SimpleCov to report code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 log
 tmp
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :test do
   gem "database_cleaner"
   gem "factory_bot_rails"
   gem "govuk-content-schema-test-helpers"
+  gem "simplecov"
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
       cucumber-messages (~> 12.2, >= 12.2.0)
     database_cleaner (1.8.5)
     diff-lcs (1.3)
+    docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     e2mmap (0.1.0)
@@ -400,6 +401,10 @@ GEM
     sidekiq-statsd (2.1.0)
       activesupport
       sidekiq (>= 3.3.1)
+    simplecov (0.19.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -468,6 +473,7 @@ DEPENDENCIES
   rubocop-govuk
   sass-rails
   sidekiq-scheduler
+  simplecov
   uglifier
   webmock
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,6 +1,9 @@
 ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"
 ENV["GOVUK_ASSET_ROOT"] = "http://static.test.gov.uk"
 
+require "simplecov"
+SimpleCov.start "rails"
+
 Before("@no-txn") { DatabaseCleaner.strategy = :truncation }
 After("@no-txn") { DatabaseCleaner.strategy = :transaction }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,9 @@ ENV["RAILS_ENV"] ||= "test"
 ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"
 ENV["GOVUK_ASSET_ROOT"] = "http://static.test.gov.uk"
 
+require "simplecov"
+SimpleCov.start "rails"
+
 require File.expand_path("../config/environment", __dir__)
 require "rspec/rails"
 


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

We should always monitor the amount of code that is exercised when
we run our tests. Note that, while the testing is split between
two framework, SimpleCov will automatically aggregate the results [1].

[1]: https://github.com/simplecov-ruby/simplecov#merging-results