### PR TITLE
Allow making a bet for a gov.uk link which has a recommended link

### DIFF
--- a/app/validators/bet_link_validator.rb
+++ b/app/validators/bet_link_validator.rb
@@ -16,16 +16,16 @@ class BetLinkValidator < ActiveModel::EachValidator
 private
 
   def validate_external_link(uri, value)
-    if %w[www.gov.uk gov.uk].include? uri.host
-      record_error("looks like an internal link so should just be a path: use /random, not gov.uk/random.")
+    if RecommendedLink.find_by(link: value).nil?
+      if %w[www.gov.uk gov.uk].include?(uri.host)
+        record_error("looks like an internal link so should just be a path: use /random, not gov.uk/random.")
+      else
+        record_error("looks like an external link, so you should first create a recommended link in search admin (click External links)")
+      end
     end
 
     unless uri.is_a?(URI::HTTP)
       record_error("looks like an external link, so you should prepend it with http:// or https://, like https://#{value}")
-    end
-
-    if RecommendedLink.find_by(link: value).nil?
-      record_error("looks like an external link, so you should first create a recommended link in search admin (click External links)")
     end
   end
 

--- a/spec/models/best_bet_spec.rb
+++ b/spec/models/best_bet_spec.rb
@@ -55,7 +55,8 @@ describe Bet do
     end
 
     context "when given a external link" do
-      subject(:bet) { described_class.new(@best_bet_attributes.merge(link: external_bet_link)) }
+      let(:subject_link) { external_bet_link }
+      subject(:bet) { described_class.new(@best_bet_attributes.merge(link: subject_link)) }
       it { is_expected.to be_valid }
 
       context "when the external link has no corresponding recommended link" do
@@ -69,8 +70,14 @@ describe Bet do
       end
 
       context "when the link is an internal link" do
-        let(:external_link) { "https://www.gov.uk/campaign" }
+        let(:subject_link) { "https://www.gov.uk/campaign" }
         it { is_expected.to_not be_valid }
+
+        context "when there is a corresponding recommended link" do
+          let(:external_link) { subject_link }
+
+          it { is_expected.to be_valid }
+        end
       end
     end
 


### PR DESCRIPTION
Normally we don't allow bets for `https;?/www.gov.uk/...` links, and
require the `/...` form.  But for paths on GOV.UK which don't have a
content item, like `https://www.gov.uk/alerts` or
`https://www.gov.uk/design-system`, we need to be able to add the full
URL.

Another approach would be to add dummy content items for these, so
every path on GOV.UK corresponds to some content.  But then we'd need
to add to the content item the information we want to appear in
search.

---

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4556753)