### PR TITLE
Use GOV.UK CI's Docker instance of MySQL 8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,7 @@
 library("govuk")
 
 node {
+  // Use GOV.UK CI's Docker instance of MySQL 8
+  govuk.setEnvar("TEST_DATABASE_URL", "mysql2://root:root@127.0.0.1:33068/search_admin_test")
   govuk.buildProject()
 }


### PR DESCRIPTION
Update the Jenkins CI configuration to use MySQL 8.

MySQL is available at port 33068 on the CI server. By explicitly setting the TEST_DATABASE_URL, we're telling Rails to use that MySQL server.

Previously, Rails implicitly used the default MySQL port 3306 which is a MySQL 5.5 server.

Trello ticket: https://trello.com/c/ILeGpfWH/24-test-search-admin-with-new-database