### PR TITLE
Bump i18n

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.4)
       domain_name (~> 0.5)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)


### PR DESCRIPTION
i18n version 1.9.0 has been yanked due to a bug so we need to bump to
1.9.1.