### PR TITLE
Remove Plek.current

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -13,7 +13,7 @@ module Services
   def self.search_api
     @search_api ||=
       GdsApi::Search.new(
-        Plek.current.find("search"),
+        Plek.find("search"),
         api_version: "V2",
         bearer_token: ENV["RUMMAGER_BEARER_TOKEN"] || "example",
       )

--- a/app/services/search_url.rb
+++ b/app/services/search_url.rb
@@ -1,6 +1,6 @@
 class SearchUrl
   def self.for(search_term)
-    base_url = Plek.current.website_root
+    base_url = Plek.new.website_root
     search_term = CGI.escape(search_term)
     random = SecureRandom.hex(10)
     "#{base_url}/search/all?keywords=#{search_term}&order=relevance&debug_score=1&cachebust=#{random}"


### PR DESCRIPTION
`Plek.current` was marked as deprecated in alphagov/plek#94. This replaces all uses of `Plek.current` to stop deprecation warnings from filling up the logs with:

"Plek.current is deprecated and will be removed. Use Plek.new or Plek.find instead."

[Trello](https://trello.com/c/vdnZ4cBq/233-replace-plekcurrent)