### PR TITLE
Dockerised app to meet replatforming standards.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.dockerignore
+.git
+.gitignore
+.github
+Dockerfile
+Jenkinsfile
+README.md
+docs
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
+
+FROM $builder_image AS builder
+
+WORKDIR /app
+
+COPY Gemfile* .ruby-version /app/
+
+RUN bundle install
+
+COPY . /app
+
+RUN bundle exec rails assets:precompile && rm -fr /app/log
+
+
+FROM $base_image
+
+ENV GOVUK_APP_NAME=search-admin
+
+WORKDIR /app
+
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+COPY --from=builder /app /app/
+
+USER app
+
+CMD bundle exec puma

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_puma"
+GovukPuma.configure_rails(self)


### PR DESCRIPTION
  Add Dockerfile which is standard we use for Ruby Apps
  Add .dockerignore to keeps image clean
  adds Puma via govuk_app_config

Tested by building the Dockerfile file locally and then running it.

https://trello.com/c/44ebF691/1026-publishing-journey-apps-migrations