### PR TITLE
Use canonical name when connecting to search-api.

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -13,7 +13,7 @@ module Services
   def self.search_api
     @search_api ||=
       GdsApi::Search.new(
-        Plek.find("search"),
+        Plek.find("search-api"),
         api_version: "V2",
         bearer_token: ENV["RUMMAGER_BEARER_TOKEN"] || "example",
       )

--- a/features/step_definitions/managing_results_steps.rb
+++ b/features/step_definitions/managing_results_steps.rb
@@ -4,7 +4,7 @@ When(/^I visit the results form$/) do
 end
 
 When(/^I type in a valid GOV.UK link$/) do
-  stub_request(:get, "https://search.test.gov.uk/content?link=/make-a-sorn")
+  stub_request(:get, "https://search-api.test.gov.uk/content?link=/make-a-sorn")
     .to_return(body: { "raw_source" => { "title" => "Stubbed page about SORN" } }.to_json)
 
   fill_in "base_path", with: "/make-a-sorn"
@@ -16,8 +16,8 @@ Then(/^I should see all information about the link$/) do
 end
 
 When(/^I click on the button to remove the result$/) do
-  stub_request(:delete, "https://search.test.gov.uk/content?link=/make-a-sorn")
-  stub_request(:get, "https://search.test.gov.uk/content?link=/make-a-sorn")
+  stub_request(:delete, "https://search-api.test.gov.uk/content?link=/make-a-sorn")
+  stub_request(:get, "https://search-api.test.gov.uk/content?link=/make-a-sorn")
     .to_return(status: 404)
   click_on "Remove result"
 end
@@ -27,7 +27,7 @@ Then(/^the result should have been removed from the index$/) do
 end
 
 When(/^I type in an non-existing GOV\.UK link$/) do
-  stub_request(:get, "https://search.test.gov.uk/content?link=/does-not-exist")
+  stub_request(:get, "https://search-api.test.gov.uk/content?link=/does-not-exist")
     .to_return(status: 404)
 
   fill_in "base_path", with: "/does-not-exist"
@@ -39,7 +39,7 @@ Then(/^I should see that the link is invalid$/) do
 end
 
 When(/^I type in a locked GOV.UK link$/) do
-  stub_request(:get, "https://search.test.gov.uk/content?link=/a-locked-document")
+  stub_request(:get, "https://search-api.test.gov.uk/content?link=/a-locked-document")
     .to_return(body: { "raw_source" => { "title" => "Stubbed page about SORN" } }.to_json)
 
   fill_in "base_path", with: "/a-locked-document"
@@ -47,7 +47,7 @@ When(/^I type in a locked GOV.UK link$/) do
 end
 
 When(/^I click on the button to remove the locked result$/) do
-  stub_request(:delete, "https://search.test.gov.uk/content?link=/a-locked-document")
+  stub_request(:delete, "https://search-api.test.gov.uk/content?link=/a-locked-document")
     .to_return(status: 423, body: { "result" => "Index is locked." }.to_json)
 
   click_on "Remove result"

--- a/features/step_definitions/similar_search_results_steps.rb
+++ b/features/step_definitions/similar_search_results_steps.rb
@@ -6,7 +6,7 @@ end
 When(/^I type in a valid GOV\.UK link with related items$/) do
   stub_request(
     :get,
-    "https://search.test.gov.uk/search.json?fields%5B%5D=taxons&filter_link=/guidance/pupil-premium-reviews",
+    "https://search-api.test.gov.uk/search.json?fields%5B%5D=taxons&filter_link=/guidance/pupil-premium-reviews",
   ).to_return(
     body: {
       "results" => [{
@@ -18,7 +18,7 @@ When(/^I type in a valid GOV\.UK link with related items$/) do
 
   stub_request(
     :get,
-    /https:\/\/search.test.gov.uk\/search.json\?.*similar_to=\/guidance\/pupil-premium-reviews.*/,
+    /https:\/\/search-api.test.gov.uk\/search.json\?.*similar_to=\/guidance\/pupil-premium-reviews.*/,
   ).to_return(
     body: {
       "results" => [{

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,9 +31,9 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
   config.before(:each) do
-    # search URLs are of the form: http://search.dev.gov.uk/mainstream/document/http://test.dev.gov.uk
+    # search URLs are of the form: http://search-api.dev.gov.uk/mainstream/document/http://test.dev.gov.uk
     # The part after /document/ is optional depending on the request type
-    search_url_regex = %r{#{Plek.find('search')}/.+/.+(/.*)?}
+    search_url_regex = %r{#{Plek.find('search-api')}/.+/.+(/.*)?}
     stub_request(:post, search_url_regex)
     stub_request(:delete, search_url_regex)
   end


### PR DESCRIPTION
See alphagov/gds-api-adapters#1170 for context.