### PR TITLE
Hold back a bad version of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "rails", "7.0.4"
 
 gem "bootsnap"
 gem "generic_form_builder"
+gem "mail", "~> 2.7.1" # TODO: remove once https://www.github.com/mikel/mail/issues/1489 is fixed.
 gem "mysql2"
 gem "sassc-rails"
 gem "sidekiq-scheduler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    date (3.3.1)
+    date (3.3.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
@@ -234,11 +234,8 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     mail-notify (1.1.0)
       actionmailer (>= 5.2.4.6)
       actionpack (>= 5.2.7.1)
@@ -259,7 +256,7 @@ GEM
     multi_test (1.1.0)
     multi_xml (0.6.0)
     mysql2 (0.5.4)
-    net-imap (0.3.2)
+    net-imap (0.3.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -506,6 +503,7 @@ DEPENDENCIES
   govuk_publishing_components
   govuk_sidekiq
   listen
+  mail (~> 2.7.1)
   mail-notify
   mysql2
   plek


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is https://www.github.com/mikel/mail/issues/1489. We can remove this workaround once the bug is fixed.

Tested: deployed to the integration cluster and the app no longer fails on startup.