### PR TITLE
Replace archived govuk-content-schema-test-helpers with govuk_schemas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :test do
   gem "cucumber-rails", require: false
   gem "database_cleaner"
   gem "factory_bot_rails"
-  gem "govuk-content-schema-test-helpers"
+  gem "govuk_schemas"
   gem "simplecov"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,8 +171,6 @@ GEM
     generic_form_builder (0.13.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_admin_template (6.10.0)
       bootstrap-sass (~> 3.4)
       jquery-rails (~> 4.3)
@@ -199,6 +197,8 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
+    govuk_schemas (4.5.0)
+      json-schema (>= 2.8, < 3.1)
     govuk_sidekiq (5.0.0)
       gds-api-adapters (>= 19.1.0)
       govuk_app_config (>= 1.1)
@@ -218,8 +218,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.6.2)
-    json-schema (2.8.1)
-      addressable (>= 2.4)
+    json-schema (3.0.0)
+      addressable (>= 2.8)
     jwt (2.5.0)
     kgio (2.11.4)
     kramdown (2.4.0)
@@ -500,10 +500,10 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso
   generic_form_builder
-  govuk-content-schema-test-helpers
   govuk_admin_template
   govuk_app_config
   govuk_publishing_components
+  govuk_schemas
   govuk_sidekiq
   listen
   mail-notify

--- a/spec/presenters/external_content_presenter_spec.rb
+++ b/spec/presenters/external_content_presenter_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "govuk_schemas/validator"
 
 RSpec.describe ExternalContentPresenter do
   context "for the publishing API" do
@@ -42,13 +43,13 @@ RSpec.describe ExternalContentPresenter do
     end
 
     def assert_valid_content_item(payload)
-      validator = GovukContentSchemaTestHelpers::Validator.new(
+      validator = GovukSchemas::Validator.new(
         "external_content",
-        "schema",
+        "publisher",
         payload,
       )
 
-      expect(validator).to be_valid
+      expect(validator.valid?).to be true
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,11 +41,4 @@ RSpec.configure do |config|
   config.before(:each, type: "controller") do
     login_as_stub_user
   end
-
-  require "govuk-content-schema-test-helpers"
-
-  GovukContentSchemaTestHelpers.configure do |schema_config|
-    schema_config.schema_type = "publisher_v2"
-    schema_config.project_root = Rails.root
-  end
 end


### PR DESCRIPTION
**What**

This is part of the work to replace all occurrences of [govuk-content-schema-test-helpers](https://github.com/alphagov/govuk-content-schema-test-helpers) with [govuk_schemas](https://github.com/alphagov/govuk_schemas).

**Why**

[govuk-content-schema-test-helpers](https://github.com/alphagov/govuk-content-schema-test-helpers) is deprecated, archived, and is no longer being updated. But is still used by [feedback](https://github.com/alphagov/feedback).

Link to [Trello](https://trello.com/c/rkw0A4r1/238-switch-govuk-content-schema-test-helpers-for-govukschemas-in-search-admin) card

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.