### PR TITLE
This sets the asset path to include the application name.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,10 @@ module SearchAdmin
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
 
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/search-admin"
+
     # Enable per-form CSRF tokens. Previous versions had false.
     config.action_controller.per_form_csrf_tokens = false
 


### PR DESCRIPTION
Background to this change can be found here:
alphagov/manuals-publisher#2004

This has been tested, by deploying the branch into Integration
https://search-admin.eks.integration.govuk.digital/
https://search-admin.integration.publishing.service.gov.uk/