### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem "rails", "7.0.4"
 
 gem "bootsnap", require: false
 gem "generic_form_builder"
-gem "mail", "~> 2.8.0" # TODO: remove once https://www.github.com/mikel/mail/issues/1489 is fixed.
 gem "mysql2"
 gem "sassc-rails"
 gem "sidekiq-scheduler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -502,7 +502,6 @@ DEPENDENCIES
   govuk_schemas
   govuk_sidekiq
   listen
-  mail (~> 2.8.0)
   mail-notify
   mysql2
   plek


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
