### PR TITLE
Add brakeman ignore for Ruby 2.7.6 end of life error

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,25 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 123,
+      "fingerprint": "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 2.7.6 ends on 2023-03-31",
+      "file": "Gemfile.lock",
+      "line": 316,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
+    }
+  ],
+  "updated": "2023-01-31 11:13:02 +0000",
+  "brakeman_version": "5.4.0"
+}


### PR DESCRIPTION
We are not yet ready to roll out upgrades to 3.2.0. Once we are we can remove this file. Until then - this will stop the CI errors and allow us to deploy the app.

[Trello](https://trello.com/c/g5rkYLRO/330-update-ruby-version-on-search-admin)