### PR TITLE
Fix release version in footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,9 @@
       <%= yield %>
     </main>
 
-    <p class="govuk-body">Version: <%= CURRENT_RELEASE_SHA %></p>
+    <% if ENV.key? "SENTRY_RELEASE" %>
+      <p class="govuk-body-s">Version: <%= ENV["SENTRY_RELEASE"] %></p>
+    <% end %>
   </div>
 
   <%= render "govuk_publishing_components/components/layout_footer", {} %>

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,7 +1,0 @@
-revision_file = Rails.root.join("REVISION")
-if File.exist?(revision_file)
-  revision = File.read(revision_file).strip
-  CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
-else
-  CURRENT_RELEASE_SHA = "development".freeze
-end


### PR DESCRIPTION
This has been broken since we moved to EKS and the SHA is no longer provided.

We can use the [SENTRY_RELEASE](https://github.com/alphagov/govuk-helm-charts/blob/077117e7f40c096a958f9e0b853a2bd76cf43f26/charts/generic-govuk-app/templates/deployment.yaml#L92C1-L92C1) environment variable which is defined for every app and takes its value from the container image's tag.

Before:
<img width="1007" alt="Screenshot 2023-09-25 at 12 05 40" src="https://github.com/alphagov/search-admin/assets/19667619/e21a4683-4d5c-48b0-b727-6c7b59a611f2">

After (tested on Integration):
<img width="994" alt="Screenshot 2023-09-25 at 12 05 52" src="https://github.com/alphagov/search-admin/assets/19667619/d66d9936-ba40-450e-8665-ff4f5e18e9f2">


Trello card: https://trello.com/c/uoKDUcbV/3182-fix-broken-version-footer-in-publishing-apps-2