### PR TITLE
Add extra fields to Queries CSV download

### DIFF
--- a/app/models/bet.rb
+++ b/app/models/bet.rb
@@ -92,4 +92,8 @@ class Bet < ApplicationRecord
   def query_object
     query
   end
+
+  def last_edit_date
+    updated_at || created_at
+  end
 end

--- a/app/models/bet.rb
+++ b/app/models/bet.rb
@@ -96,4 +96,8 @@ class Bet < ApplicationRecord
   def last_edit_date
     updated_at || created_at
   end
+
+  def author
+    user.try(:name) || " "
+  end
 end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -28,7 +28,7 @@ class Query < ApplicationRecord
 
   def self.to_csv(*_args)
     CSV.generate do |csv|
-      csv << ["query", "match_type", "link", "best/worst", "comment", "status"]
+      csv << ["query", "match_type", "link", "best/worst", "comment", "status", "position"]
 
       all.includes(:bets).find_each do |query|
         query.bets.each do |bet|
@@ -37,7 +37,8 @@ class Query < ApplicationRecord
                   bet.link,
                   bet.is_best ? "best" : "worst",
                   bet.comment.to_s,
-                  bet.valid_until]
+                  bet.valid_until,
+                  bet.position]
         end
       end
     end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -28,7 +28,7 @@ class Query < ApplicationRecord
 
   def self.to_csv(*_args)
     CSV.generate do |csv|
-      csv << ["query", "match_type", "link", "best/worst", "comment", "status", "position"]
+      csv << ["query", "match_type", "link", "best/worst", "comment", "status", "position", "last edit date"]
 
       all.includes(:bets).find_each do |query|
         query.bets.each do |bet|
@@ -38,7 +38,8 @@ class Query < ApplicationRecord
                   bet.is_best ? "best" : "worst",
                   bet.comment.to_s,
                   bet.valid_until,
-                  bet.position]
+                  bet.position,
+                  bet.last_edit_date.strftime("%d %b %Y")]
         end
       end
     end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -28,7 +28,7 @@ class Query < ApplicationRecord
 
   def self.to_csv(*_args)
     CSV.generate do |csv|
-      csv << ["query", "match_type", "link", "best/worst", "comment", "status", "position", "last edit date"]
+      csv << ["query", "match_type", "link", "best/worst", "comment", "status", "position", "last edit date", "author"]
 
       all.includes(:bets).find_each do |query|
         query.bets.each do |bet|
@@ -39,7 +39,8 @@ class Query < ApplicationRecord
                   bet.comment.to_s,
                   bet.valid_until,
                   bet.position,
-                  bet.last_edit_date.strftime("%d %b %Y")]
+                  bet.last_edit_date.strftime("%d %b %Y"),
+                  bet.author]
         end
       end
     end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -28,7 +28,7 @@ class Query < ApplicationRecord
 
   def self.to_csv(*_args)
     CSV.generate do |csv|
-      csv << ["query", "match_type", "link", "best/worst", "comment"]
+      csv << ["query", "match_type", "link", "best/worst", "comment", "status"]
 
       all.includes(:bets).find_each do |query|
         query.bets.each do |bet|
@@ -36,7 +36,8 @@ class Query < ApplicationRecord
                   query.match_type,
                   bet.link,
                   bet.is_best ? "best" : "worst",
-                  bet.comment.to_s]
+                  bet.comment.to_s,
+                  bet.valid_until]
         end
       end
     end

--- a/app/views/queries/_bet_table.html.erb
+++ b/app/views/queries/_bet_table.html.erb
@@ -26,7 +26,7 @@
         <%= t.cell bet.position %>
       <% end %>
       <%= t.cell bet.last_edit_date.strftime("%d %b %Y") %>
-      <%= t.cell bet.try(:user).try(:name) || " " %>
+      <%= t.cell bet.author %>
       <%= t.cell bet.valid_until %>
       <% if bet.active? %>
         <%= t.cell button_to 'Deactivate', deactivate_bet_path(bet), class: "govuk-button govuk-button--secondary" %>

--- a/app/views/queries/_bet_table.html.erb
+++ b/app/views/queries/_bet_table.html.erb
@@ -25,7 +25,7 @@
       <% if type == :best %>
         <%= t.cell bet.position %>
       <% end %>
-      <%= t.cell (bet.updated_at || bet.created_at).strftime("%d %b %Y") %>
+      <%= t.cell bet.last_edit_date.strftime("%d %b %Y") %>
       <%= t.cell bet.try(:user).try(:name) || " " %>
       <%= t.cell bet.valid_until %>
       <% if bet.active? %>

--- a/features/support/best_bets.rb
+++ b/features/support/best_bets.rb
@@ -103,11 +103,11 @@ end
 def check_for_queries_in_csv_format(queries)
   headers, *rows = *CSV.parse(page.body)
 
-  expect(headers).to eq(["query", "match_type", "link", "best/worst", "comment"])
+  expect(headers).to eq(["query", "match_type", "link", "best/worst", "comment", "status"])
 
   queries.each do |query|
     query.bets.each do |bet|
-      expect(rows).to include([query.query, query.match_type, bet.link, "best", ""])
+      expect(rows).to include([query.query, query.match_type, bet.link, "best", "", "Permanent"])
     end
   end
 end

--- a/features/support/best_bets.rb
+++ b/features/support/best_bets.rb
@@ -103,7 +103,7 @@ end
 def check_for_queries_in_csv_format(queries)
   headers, *rows = *CSV.parse(page.body)
 
-  expect(headers).to eq(["query", "match_type", "link", "best/worst", "comment", "status", "position"])
+  expect(headers).to eq(["query", "match_type", "link", "best/worst", "comment", "status", "position", "last edit date"])
 
   queries.each do |query|
     query.bets.each do |bet|

--- a/features/support/best_bets.rb
+++ b/features/support/best_bets.rb
@@ -103,7 +103,7 @@ end
 def check_for_queries_in_csv_format(queries)
   headers, *rows = *CSV.parse(page.body)
 
-  expect(headers).to eq(["query", "match_type", "link", "best/worst", "comment", "status", "position", "last edit date"])
+  expect(headers).to eq(["query", "match_type", "link", "best/worst", "comment", "status", "position", "last edit date", "author"])
 
   queries.each do |query|
     query.bets.each do |bet|

--- a/features/support/best_bets.rb
+++ b/features/support/best_bets.rb
@@ -103,7 +103,7 @@ end
 def check_for_queries_in_csv_format(queries)
   headers, *rows = *CSV.parse(page.body)
 
-  expect(headers).to eq(["query", "match_type", "link", "best/worst", "comment", "status"])
+  expect(headers).to eq(["query", "match_type", "link", "best/worst", "comment", "status", "position"])
 
   queries.each do |query|
     query.bets.each do |bet|

--- a/spec/models/best_bet_spec.rb
+++ b/spec/models/best_bet_spec.rb
@@ -163,6 +163,16 @@ describe Bet do
       end
     end
 
+    describe "#author" do
+      it "should return the name of user" do
+        user_name = "Ahsoka Tano"
+        user = create(:user, name: user_name)
+        best_bet = Bet.new(@best_bet_attributes.merge(user_id: user.id))
+
+        expect(best_bet.author).to eq(user_name)
+      end
+    end
+
     describe "bet_date validations" do
       it "Temporary bets must have an expiration date" do
         bet_date_attrs = { permanent: false, expiration_date: "" }

--- a/spec/models/best_bet_spec.rb
+++ b/spec/models/best_bet_spec.rb
@@ -78,6 +78,29 @@ describe Bet do
           it { is_expected.to be_valid }
         end
       end
+
+      describe "#valid_until" do
+        it "valid_until is permanent if permanent is set to true" do
+          best_bet = Bet.new(@best_bet_attributes)
+
+          expect(best_bet.valid_until).to eq("Permanent")
+        end
+
+        it "returns an expiry date if expiration date is in the future" do
+          expiration_date = 1.day.from_now
+          bet_date_attrs = { permanent: false, expiration_date: }
+          best_bet = Bet.new(@best_bet_attributes.merge(bet_date_attrs))
+
+          expect(best_bet.valid_until).to eq("Expires #{expiration_date.strftime('%d %b %Y')}")
+        end
+
+        it "returns a status of Expired if expiration date is in the past" do
+          bet_date_attrs = { permanent: false }
+          best_bet = Bet.new(@best_bet_attributes.merge(bet_date_attrs))
+
+          expect(best_bet.valid_until).to eq("Expired")
+        end
+      end
     end
 
     context "when given an internal link" do


### PR DESCRIPTION
# What's changed?

Adds a extra fields to the CSV download of queries. New fields added are:

- Status
- Position
- Last edit date
- Author

The information in these fields is already being displayed in the Queries and Bets pages in the UI.

# Why?

To help with the auditing of Best Bets.

# Expected changes

<img width="455" alt="search-admin-csv" src="https://github.com/alphagov/search-admin/assets/5793815/0d31a974-4a62-4a99-976e-5111d2290bdb">
