### PR TITLE
Add sentry-sidekiq to track Sidekiq errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "bootsnap", require: false
 gem "generic_form_builder"
 gem "mysql2"
 gem "sassc-rails"
+gem "sentry-sidekiq"
 gem "sidekiq-scheduler"
 gem "sprockets-rails"
 gem "uglifier"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -657,6 +657,9 @@ GEM
       sentry-ruby (~> 5.12.0)
     sentry-ruby (5.12.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.12.0)
+      sentry-ruby (~> 5.12.0)
+      sidekiq (>= 3.0)
     sidekiq (6.5.5)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -740,6 +743,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sassc-rails
+  sentry-sidekiq
   sidekiq-scheduler
   simplecov
   sprockets-rails


### PR DESCRIPTION
The default configuration comes from GovukError in https://github.com/alphagov/govuk_app_config

To address the following warning:

```
Warning: GovukError is not configured to track Sidekiq errors,
install the sentry-sidekiq gem to track them.
```