### PR TITLE
Add once_off rake task to unpublish/destroy all external links that are council homepages

### DIFF
--- a/lib/tasks/once_off/remove_council_external_links.rake
+++ b/lib/tasks/once_off/remove_council_external_links.rake
@@ -1,0 +1,18 @@
+# External links to council homepages are now published and managed
+# by Local Links Manager.
+namespace :once_off do
+  desc "Unpublish all external links that are council homepages"
+  task remove_council_external_links: :environment do
+    non_councils = [
+      "Corporation of London",
+      "Comhairle nan Eilean Siar",
+      "City and County of Swansea",
+    ]
+
+    council_links = RecommendedLink.where("title LIKE '%Council%'") + RecommendedLink.where(title: non_councils)
+    council_links.each do |link|
+      ExternalContentPublisher.unpublish(link)
+      link.destroy!
+    end
+  end
+end


### PR DESCRIPTION
Local Links Manager has a more up-to-date list of councils and better support for maintaining links, and should handle publishing the external content items for their homepage URLs.

https://trello.com/c/p6bYucUh/2334-local-links-manager-should-publish-council-homepages-to-the-search-api