### PR TITLE
Migrate to Dart SASS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@ tmp
 coverage
 node_modules
 yarn-error.log
-public/assets
 
+public/assets
+/app/assets/builds/*
+!/app/assets/builds/.keep
 
 # https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
 .yarn/*

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ source "https://rubygems.org"
 gem "rails", "7.1.3.2"
 
 gem "bootsnap", require: false
+gem "dartsass-rails"
 gem "generic_form_builder"
 gem "mysql2"
-gem "sassc-rails"
 gem "sentry-sidekiq"
 gem "sidekiq-scheduler"
 gem "sprockets-rails"
@@ -20,6 +20,10 @@ gem "govuk_publishing_components"
 gem "govuk_sidekiq"
 gem "mail-notify"
 gem "plek"
+
+group :development do
+  gem "foreman"
+end
 
 group :test do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,9 @@ GEM
       cucumber (>= 5, < 10)
       railties (>= 5.2, < 8)
     cucumber-tag-expressions (6.1.0)
+    dartsass-rails (0.5.0)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -161,6 +164,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.16.3)
+    foreman (0.88.1)
     fugit (1.10.1)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
@@ -661,14 +665,11 @@ GEM
     ruby-progressbar (1.13.0)
     rufus-scheduler (3.9.1)
       fugit (~> 1.1, >= 1.1.6)
+    sass-embedded (1.75.0)
+      google-protobuf (>= 3.25, < 5.0)
+      rake (>= 13.0.0)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     sentry-rails (5.17.2)
       railties (>= 5.0)
       sentry-ruby (~> 5.17.2)
@@ -739,8 +740,10 @@ DEPENDENCIES
   bootsnap
   brakeman
   cucumber-rails
+  dartsass-rails
   database_cleaner
   factory_bot_rails
+  foreman
   gds-api-adapters
   gds-sso
   generic_form_builder
@@ -758,7 +761,6 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails
   rubocop-govuk
-  sassc-rails
   sentry-sidekiq
   sidekiq-scheduler
   simplecov

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3073}
-worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+web: bin/rails server --restart
+worker: bundle exec sidekiq -C ./config/sidekiq.yml
+css: bin/rails dartsass:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,2 @@
-//= link application.css
+//= link_tree ../builds
 //= link application.js

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+exec foreman start -f Procfile.dev "$@"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,7 @@ Rails.application.configure do
 
   # Allow requests for all domains e.g. <app>.dev.gov.uk
   config.hosts.clear
+
+  # Ensure latest assets are always available when using Dart SASS in watch mode
+  config.assets.digest = false
 end

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,2 +1,0 @@
-require "govuk_app_config/govuk_unicorn"
-GovukUnicorn.configure(self)


### PR DESCRIPTION
`sassc` is deprecated and support will be going away soon (both upstream and in GOV.UK Frontend), so this is a good opportunity to move away from it (and also prepare for some general asset pipeline updates in this repo).

- Replace `sassc-rails` with `dartsass-rails` and complete setup steps
- Introduce `app/assets/builds` folder for Dart SASS
- Update `Procfile` to actually be correct and up to date, and rename `Procfile.dev` to reflect what it _actually_ does
- Add conventional Rails `bin/dev` command
- Ensure no asset digests are generated in `development` environment
- Remove unneeded Unicorn configuration (this is left over from the pre-Puma days and was only used in the `Procfile`)