### PR TITLE
Fix Sidekiq not running

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem "dartsass-rails"
 gem "generic_form_builder"
 gem "mysql2"
 gem "sentry-sidekiq"
-gem "sidekiq-scheduler"
 gem "sprockets-rails"
 gem "uglifier"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,8 +151,6 @@ GEM
     domain_name (0.6.20240107)
     drb (2.2.1)
     erubi (1.12.0)
-    et-orbi (1.2.11)
-      tzinfo
     execjs (2.9.1)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
@@ -165,9 +163,6 @@ GEM
       net-http
     ffi (1.16.3)
     foreman (0.88.1)
-    fugit (1.10.1)
-      et-orbi (~> 1, >= 1.2.7)
-      raabro (~> 1.4)
     gds-api-adapters (95.0.1)
       addressable
       link_header
@@ -538,7 +533,6 @@ GEM
     public_suffix (5.0.5)
     puma (6.4.2)
       nio4r (~> 2.0)
-    raabro (1.4.0)
     racc (1.7.3)
     rack (2.2.9)
     rack-protection (3.2.0)
@@ -663,8 +657,6 @@ GEM
     rubocop-rspec_rails (2.28.2)
       rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
-    rufus-scheduler (3.9.1)
-      fugit (~> 1.1, >= 1.1.6)
     sass-embedded (1.75.0)
       google-protobuf (>= 3.25, < 5.0)
       rake (>= 13.0.0)
@@ -683,10 +675,6 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
-    sidekiq-scheduler (5.0.3)
-      rufus-scheduler (~> 3.2)
-      sidekiq (>= 6, < 8)
-      tilt (>= 1.4.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -708,7 +696,6 @@ GEM
     sys-uname (1.2.3)
       ffi (~> 1.1)
     thor (1.3.1)
-    tilt (2.3.0)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -762,7 +749,6 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sentry-sidekiq
-  sidekiq-scheduler
   simplecov
   sprockets-rails
   uglifier

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,2 @@
+# govuk-helm-charts expects a sidekiq.yml file to be present in the config directory (unless
+# manually overriding the default `worker` command) and will fail to run workers without one


### PR DESCRIPTION
- Remove unnecessary `sidekiq-scheduler` gem (if we ever add scheduled tasks again, these should be run as k8s cron jobs)
- Add empty `sidekiq.yml` configuration file as the GOV.UK k8s platform expects it to be present in the default configuration