### PR TITLE
Fix most glaring Ruby deprecation errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -755,4 +755,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.5.9

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
   include GDS::SSO::User
 
-  serialize :permissions, Array
+  serialize :permissions, type: Array
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,18 +45,5 @@ module SearchAdmin
     # Set asset path to be application specific so that we can put all GOV.UK
     # assets into an S3 bucket and distinguish app by path.
     config.assets.prefix = "/assets/search-admin"
-
-    # Enable per-form CSRF tokens. Previous versions had false.
-    config.action_controller.per_form_csrf_tokens = false
-
-    # Enable origin-checking CSRF mitigation. Previous versions had false.
-    config.action_controller.forgery_protection_origin_check = false
-
-    # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
-    # Previous versions had false.
-    ActiveSupport.to_time_preserves_timezone = false
-
-    # Require `belongs_to` associations by default. Previous versions had false.
-    config.active_record.belongs_to_required_by_default = false
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ WebMock.disable_net_connect!
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
-  config.fixture_path = Rails.root.join("/spec/fixtures")
+  config.fixture_paths = [Rails.root.join("spec/fixtures")]
   config.use_transactional_fixtures = true
   config.infer_base_class_for_anonymous_controllers = false
   config.order = "random"


### PR DESCRIPTION
- Update underlying Bundler version to `2.5.x`
- Remove legacy settings from `config/application.rb`
- Specify required keyword param for `serialize` in `User` model
- Use new `fixture_paths` array in RSpec configuration