### PR TITLE
Fix frontend deprecation issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "generic_form_builder"
 gem "mysql2"
 gem "sentry-sidekiq"
 gem "sprockets-rails"
-gem "uglifier"
 
 # GDS managed gems
 gem "gds-api-adapters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -699,8 +699,6 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     uri (0.13.0)
     version_gem (1.1.4)
@@ -751,7 +749,6 @@ DEPENDENCIES
   sentry-sidekiq
   simplecov
   sprockets-rails
-  uglifier
   webmock
 
 BUNDLED WITH

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,3 @@
-$govuk-typography-use-rem: false;
 @import "govuk_publishing_components/all_components";
 
 // by default cells have a bottom border applied

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,0 +1,4 @@
+# Quieten warnings from external dependencies
+# This helps reduce the noise in the logs caused by govuk_frontend still supporting legacy SassC.
+# TODO: Remove this once govuk_frontend no longer supports legacy SassC (slated for 6.0).
+Rails.application.config.dartsass.build_options << " --quiet-deps"


### PR DESCRIPTION
- Remove unneeded `uglifier` gem (even if it was still used, assets are served compressed from the CDN anyway)
- Quiet deprecation warnings from dependencies in Dart SASS initializer to fix issue with GOV.UK Frontend having lots of warnings with Dart SASS until 6.0 is out
- Remove no longer valid GOV.UK Frontend configuration option `govuk-typography-use-rem`