### PR TITLE
Remove legacy controller testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ end
 group :test, :development do
   gem "listen"
   gem "pry-byebug"
-  gem "rails-controller-testing" # support `expect(..).to render_template(..)` for rails >= 5.0
   gem "rspec-rails"
   gem "rubocop-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -561,10 +561,6 @@ GEM
       activesupport (= 7.1.3.2)
       bundler (>= 1.15.0)
       railties (= 7.1.3.2)
-    rails-controller-testing (1.0.5)
-      actionpack (>= 5.0.1.rc1)
-      actionview (>= 5.0.1.rc1)
-      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -743,7 +739,6 @@ DEPENDENCIES
   plek
   pry-byebug
   rails (= 7.1.3.2)
-  rails-controller-testing
   rspec-rails
   rubocop-govuk
   sentry-sidekiq

--- a/spec/controllers/recommended_links_controller_spec.rb
+++ b/spec/controllers/recommended_links_controller_spec.rb
@@ -25,11 +25,6 @@ describe RecommendedLinksController do
         post :create, params: { recommended_link: recommended_link_params.merge(title: nil) }
         expect(flash[:alert]).to include("could not create")
       end
-
-      it "renders the new action" do
-        post :create, params: { recommended_link: recommended_link_params.merge(title: nil) }
-        expect(response).to render_template("new")
-      end
     end
 
     context "on success" do
@@ -69,11 +64,6 @@ describe RecommendedLinksController do
       it "alerts the user" do
         update_recommended_link(title: nil)
         expect(flash[:alert]).to include("could not update")
-      end
-
-      it "renders the edit action" do
-        update_recommended_link(title: nil)
-        expect(response).to render_template("edit")
       end
     end
 


### PR DESCRIPTION
Asserting that a controller renders a template is not particularly valuable and support for this has been removed from upstream Rails. The test for the flash being added is good enough for these scenarios for now.

- Remove `rails-controller-testing` gem dependency
- Remove two remaining controller tests