### PR TITLE
Use GOV.UK Design System Form Builder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem "rails", "7.1.3.2"
 
 gem "bootsnap", require: false
 gem "dartsass-rails"
-gem "generic_form_builder"
 gem "mysql2"
 gem "sentry-sidekiq"
 gem "sprockets-rails"
@@ -18,6 +17,9 @@ gem "govuk_publishing_components"
 gem "govuk_sidekiq"
 gem "mail-notify"
 gem "plek"
+
+# X-Gov gems
+gem "govuk_design_system_formbuilder"
 
 group :development do
   gem "foreman"
@@ -36,7 +38,6 @@ end
 group :test, :development do
   gem "listen"
   gem "pry-byebug"
-  gem "rails-controller-testing" # support `expect(..).to render_template(..)` for rails >= 5.0
   gem "rspec-rails"
   gem "rubocop-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,6 @@ GEM
       rails (>= 6)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    generic_form_builder (0.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
@@ -201,6 +200,11 @@ GEM
       sentry-rails (~> 5.3)
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
+    govuk_design_system_formbuilder (5.3.2)
+      actionview (>= 6.1)
+      activemodel (>= 6.1)
+      activesupport (>= 6.1)
+      html-attributes-utils (~> 1)
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
@@ -222,6 +226,8 @@ GEM
       sidekiq (~> 6.5, >= 6.5.12)
     hashdiff (1.1.0)
     hashie (5.0.0)
+    html-attributes-utils (1.0.2)
+      activesupport (>= 6.1.4.4)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -561,10 +567,6 @@ GEM
       activesupport (= 7.1.3.2)
       bundler (>= 1.15.0)
       railties (= 7.1.3.2)
-    rails-controller-testing (1.0.5)
-      actionpack (>= 5.0.1.rc1)
-      actionview (>= 5.0.1.rc1)
-      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -731,9 +733,9 @@ DEPENDENCIES
   foreman
   gds-api-adapters
   gds-sso
-  generic_form_builder
   govuk_admin_template
   govuk_app_config
+  govuk_design_system_formbuilder
   govuk_publishing_components
   govuk_schemas
   govuk_sidekiq
@@ -743,7 +745,6 @@ DEPENDENCIES
   plek
   pry-byebug
   rails (= 7.1.3.2)
-  rails-controller-testing
   rspec-rails
   rubocop-govuk
   sentry-sidekiq

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   before_action :authenticate_user!
 
+  default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+
   def admin_user?
     current_user.permissions.include?("admin")
   end

--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -20,7 +20,6 @@ class RecommendedLinksController < ApplicationController
 
       redirect_to recommended_link_path(@recommended_link), notice: "Your external link was created successfully"
     else
-      flash[:alert] = "We could not create your external link"
       render :new
     end
   end
@@ -42,7 +41,6 @@ class RecommendedLinksController < ApplicationController
 
       redirect_to recommended_link_path(@recommended_link), notice: "Your external link was updated successfully"
     else
-      flash[:alert] = "We could not update your external link"
       render :edit
     end
   end
@@ -75,11 +73,5 @@ private
     params.require(:recommended_link)
       .permit(:link, :title, :description, :keywords, :comment)
       .merge(user_id: current_user.id)
-  end
-
-  def check_for_duplicate_recommended_link(recommended_link)
-    if recommended_link.errors.include?(:recommended_link)
-      RecommendedLink.where(link: recommended_link.link).first
-    end
   end
 end

--- a/app/models/recommended_link.rb
+++ b/app/models/recommended_link.rb
@@ -1,7 +1,7 @@
 class RecommendedLink < ApplicationRecord
   validates :title, :link, :description, :content_id, presence: true
-  validates :link, uniqueness: { case_sensitive: true }, url: true
-  validates :content_id, uniqueness: { case_sensitive: true }
+  validates :link, uniqueness: { case_sensitive: true, message: :unique }, url: { message: :url }
+  validates :content_id, uniqueness: { case_sensitive: true, message: :unique }
 
   def format
     uri = URI(link)

--- a/app/views/recommended_links/_form.html.erb
+++ b/app/views/recommended_links/_form.html.erb
@@ -1,49 +1,11 @@
 <%= form_for(recommended_link) do |f| %>
-  <% errors = recommended_link.errors.messages %>
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: 'Link'
-    },
-    name: "recommended_link[link]",
-    value: recommended_link.link,
-    error_message: ("Link #{errors[:link].join(' or ')}" if errors[:link].present?)
-  } %>
+  <%= f.govuk_error_summary link_base_errors_to: :link %>
 
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: 'Title'
-    },
-    name: "recommended_link[title]",
-    value: recommended_link.title,
-    error_message: ("Title #{errors[:title][0]}" if errors[:title].present?)
-  } %>
+  <%= f.govuk_text_field :link %>
+  <%= f.govuk_text_field :title %>
+  <%= f.govuk_text_area :description %>
+  <%= f.govuk_text_area :keywords %>
+  <%= f.govuk_text_area :comment %>
 
-  <%= render "govuk_publishing_components/components/textarea", {
-    label: {
-      text: 'Description'
-    },
-    name: "recommended_link[description]",
-    value: recommended_link.description,
-    error_message: ("Description #{errors[:description][0]}" if errors[:description].present?)
-  } %>
-
-  <%= render "govuk_publishing_components/components/textarea", {
-    label: {
-      text: 'Keywords'
-    },
-    name: "recommended_link[keywords]",
-    value: recommended_link.keywords
-  } %>
-
-  <%= render "govuk_publishing_components/components/textarea", {
-    label: {
-      text: 'Comment'
-    },
-    name: "recommended_link[comment]",
-    value: recommended_link.comment
-  } %>
-
-  <%= render "govuk_publishing_components/components/button", {
-    text: "Save"
-  } %>
+  <%= f.govuk_submit "Save" %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,8 +38,6 @@ module SearchAdmin
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-    config.action_view.default_form_builder = GenericFormBuilder
-    config.action_view.field_error_proc = proc { |html_tag, _| html_tag }
 
     # Using a sass css compressor causes a scss file to be processed twice
     # (once to build, once to compress) which breaks the usage of "unquote"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,33 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  helpers:
+    label:
+      recommended_link:
+        link: URL
+        title: Title
+        description: Description
+        keywords: Keywords (optional)
+        comment: Comment (optional)
+    hint:
+      recommended_link:
+        link: "for example, https://www.hogwarts.gov.uk"
+        description: >-
+          This will be shown underneath the title in search results.
+        keywords: >-
+          Enter keywords that describe the content of the link. These will not be shown to users,
+          but the search engine will use them to help users find the link.
+        comment: >-
+          Add information that will help other GOV.UK staff users understand why this external link
+          has been added. This will not be shown to users.
+  activerecord:
+    errors:
+      models:
+        recommended_link:
+          attributes:
+            link:
+              blank: "Enter a URL"
+              unique: "Another external link already exists with this URL"
+              url: "Enter a valid URL"
+            title:
+              blank: "Enter a title"
+            description:
+              blank: "Enter a description"

--- a/features/support/recommended_links.rb
+++ b/features/support/recommended_links.rb
@@ -6,7 +6,7 @@ def create_recommended_link(title: nil, link: nil, description: nil, keywords: n
 
   click_on "New external link"
 
-  fill_in "Link", with: link if link
+  fill_in "URL", with: link if link
   fill_in "Title", with: title if title
   fill_in "Description", with: description if description
   fill_in "Keywords", with: keywords if keywords

--- a/spec/controllers/recommended_links_controller_spec.rb
+++ b/spec/controllers/recommended_links_controller_spec.rb
@@ -20,18 +20,6 @@ describe RecommendedLinksController do
   end
 
   describe "#create" do
-    context "on failure" do
-      it "alerts the user" do
-        post :create, params: { recommended_link: recommended_link_params.merge(title: nil) }
-        expect(flash[:alert]).to include("could not create")
-      end
-
-      it "renders the new action" do
-        post :create, params: { recommended_link: recommended_link_params.merge(title: nil) }
-        expect(response).to render_template("new")
-      end
-    end
-
     context "on success" do
       it "sends the link to the publishing API" do
         expect(ExternalContentPublisher).to receive(:publish).with(
@@ -50,12 +38,6 @@ describe RecommendedLinksController do
         expect(response).to redirect_to(recommended_link_path(RecommendedLink.last))
       end
     end
-
-    it "displays an error if the recommended link is duplicated" do
-      create(:recommended_link, recommended_link_params)
-      post :create, params: { recommended_link: recommended_link_params }
-      expect(flash[:alert]).to include("could not create")
-    end
   end
 
   describe "#update" do
@@ -63,18 +45,6 @@ describe RecommendedLinksController do
 
     def update_recommended_link(options = {})
       put :update, params: { id: recommended_link.id, recommended_link: recommended_link_params.merge(options) }
-    end
-
-    context "on failure" do
-      it "alerts the user" do
-        update_recommended_link(title: nil)
-        expect(flash[:alert]).to include("could not update")
-      end
-
-      it "renders the edit action" do
-        update_recommended_link(title: nil)
-        expect(response).to render_template("edit")
-      end
     end
 
     context "on success" do

--- a/spec/models/recommended_link_spec.rb
+++ b/spec/models/recommended_link_spec.rb
@@ -39,7 +39,7 @@ describe RecommendedLink do
 
       record = new_recommended_link_with(attributes)
       expect(record).not_to be_valid
-      expect(record.errors.full_messages).to eq(["Link is an invalid URL"])
+      expect(record.errors.messages[:link]).to eq(["Enter a valid URL"])
     end
 
     it "is invalid with a link without a host" do
@@ -47,7 +47,7 @@ describe RecommendedLink do
 
       record = new_recommended_link_with(attributes)
       expect(record).not_to be_valid
-      expect(record.errors.full_messages).to eq(["Link does not have a valid host"])
+      expect(record.errors.messages[:link]).to eq(["Enter a valid URL"])
     end
 
     it "is invalid with a duplicate link" do


### PR DESCRIPTION
Instead of painfully manually cobbling together forms using the GOV.UK Publishing Components and losing out on all the Rails form builder convenience and deduplication, we should use standard Rails form helpers and the GOV.UK Design System Form Builder.

- Remove (no longer used anyway) `generic_form_builder` gem
- Add `govuk_design_system_formbuilder` gem and set as Rails' default form builder
- Update recommended links form view to use form builder instead of publishing components partials
- Move towards having field names and error messages in Rails i18n locale files instead of in view
- Use GOV.UK Error Summary component instead of flash alert message when record fails to save
- Rename "Link" field to "URL" to be more clear about what it is (rather than reusing the name of the thing itself which is confusing)
- Remove controller specs for external links unhappy path (we should rely on the model specs to test validation behaviour instead of "considered legacy" controller tests, and should eventually write nicer system tests)
- Remove legacy `rails-controller-testing` gem
- Remove unused `#check_for_duplicate_recommended_link` in `RecommendedLinksController`