### PR TITLE
DRY up form field generation

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -1,0 +1,34 @@
+module FormsHelper
+  def render_govuk_input(form, field_name)
+    render(
+      "govuk_publishing_components/components/input",
+      basic_field_properties(form, field_name),
+    )
+  end
+
+  def render_govuk_textarea(form, field_name)
+    render(
+      "govuk_publishing_components/components/textarea",
+      basic_field_properties(form, field_name),
+    )
+  end
+
+private
+
+  def basic_field_properties(form, field_name)
+    {
+      label: {
+        text: form.object.class.human_attribute_name(field_name),
+      },
+      name: "#{form.object_name}[#{field_name}]",
+      value: form.object[field_name],
+      error_items: error_items(form, field_name),
+    }
+  end
+
+  def error_items(form, field_name)
+    return nil if form.object.errors[field_name].empty?
+
+    form.object.errors[field_name].map { |message| { text: message } }
+  end
+end

--- a/app/views/recommended_links/_form.html.erb
+++ b/app/views/recommended_links/_form.html.erb
@@ -1,47 +1,11 @@
 <%= form_for(recommended_link) do |f| %>
   <% errors = recommended_link.errors.messages %>
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: 'Link'
-    },
-    name: "recommended_link[link]",
-    value: recommended_link.link,
-    error_message: ("Link #{errors[:link].join(' or ')}" if errors[:link].present?)
-  } %>
 
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: 'Title'
-    },
-    name: "recommended_link[title]",
-    value: recommended_link.title,
-    error_message: ("Title #{errors[:title][0]}" if errors[:title].present?)
-  } %>
-
-  <%= render "govuk_publishing_components/components/textarea", {
-    label: {
-      text: 'Description'
-    },
-    name: "recommended_link[description]",
-    value: recommended_link.description,
-    error_message: ("Description #{errors[:description][0]}" if errors[:description].present?)
-  } %>
-
-  <%= render "govuk_publishing_components/components/textarea", {
-    label: {
-      text: 'Keywords'
-    },
-    name: "recommended_link[keywords]",
-    value: recommended_link.keywords
-  } %>
-
-  <%= render "govuk_publishing_components/components/textarea", {
-    label: {
-      text: 'Comment'
-    },
-    name: "recommended_link[comment]",
-    value: recommended_link.comment
-  } %>
+  <%= render_govuk_input(f, :link) %>
+  <%= render_govuk_input(f, :title) %>
+  <%= render_govuk_textarea(f, :description) %>
+  <%= render_govuk_textarea(f, :keywords) %>
+  <%= render_govuk_textarea(f, :comment) %>
 
   <%= render "govuk_publishing_components/components/button", {
     text: "Save"


### PR DESCRIPTION
Given that using the GOV.UK Design System Form Builder isn't currently a desired option for GOV.UK Publishing apps, this starts abstracting the repetitive use of GOV.UK Publishing Components partials for form fields a little bit so it:
- becomes more obvious when looking at form view code what fields are in the form
- field names don't need to be hardcoded and repeated several times
- validation error handling can be done more effectively
- (in a future PR) translation can be used to centralise localisation