### PR TITLE
Explicitly depend on `csv` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "7.1.3.2"
 
 gem "bootsnap", require: false
+gem "csv"
 gem "dartsass-rails"
 gem "mysql2"
 gem "sentry-sidekiq"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    csv (3.3.0)
     dartsass-rails (0.5.0)
       railties (>= 6.0.0)
       sass-embedded (~> 1.63)
@@ -696,6 +697,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  csv
   dartsass-rails
   factory_bot_rails
   foreman


### PR DESCRIPTION
We use `csv` which has been extracted from the standard library into a separate gem that will no longer be bundled by default in future Ruby versions.