### PR TITLE
Add Google Tag Manager configuration to Search Admin

### DIFF
--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,0 +1,7 @@
+<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+  <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+    gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+    gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+    gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"],
+  } %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <% content_for :head do %>
   <%= stylesheet_link_tag "application", :media => "all" %>
   <%= csp_meta_tag %>
+  <%= render "layouts/google_tag_manager" %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/layout_for_admin", {


### PR DESCRIPTION
Based on the work we did previously on publisher in alphagov/publisher#1963

Tested locally with:

    GOOGLE_TAG_MANAGER_AUTH=some-auth
    GOOGLE_TAG_MANAGER_ID=some-id
    GOOGLE_TAG_MANAGER_PREVIEW=some-preview

Gives this snippet in <head>:

    <script>
    //<![CDATA[
    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
      'https://www.googletagmanager.com/gtm.js?id='+i+dl+'&gtm_cookies_win=x&gtm_auth=some-auth&gtm_preview=some-preview';f.parentNode.insertBefore(j,f);
    })(window,document,'script','dataLayer','some-id');

    //]]>
    </script>

We'll need a follow up PR to pass these environment variables through in govuk-helm-charts.