### PR TITLE
Remove Snyk job from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,6 @@ on:
   pull_request:
 
 jobs:
-  snyk-security:
-    name: SNYK security analysis
-    uses: alphagov/govuk-infrastructure/.github/workflows/snyk-security.yml@main
-    secrets: inherit
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-
   codeql-sast:
     name: CodeQL SAST scan
     uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main


### PR DESCRIPTION
We've decided to stop using Snyk for the reasons described [here](https://docs.google.com/document/d/1elh1hQoxcE-oMcHEPH3NuipFw0vkDe_T3wWmzqXRCoA/edit#heading=h.nwe71munrcvd). 

This PR will be reviewed and merged by the Platform Security and Reliability team. Any questions or concerns, please reach out in our channel: #govuk-platform-security-reliability-team.

[Trello card](https://trello.com/c/z36ZcRzL/3532-remove-snyk-jobs-from-all-ci-pipelines-3)