### PR TITLE
Add scaffold for Controls

### DIFF
--- a/app/controllers/controls_controller.rb
+++ b/app/controllers/controls_controller.rb
@@ -1,0 +1,5 @@
+class ControlsController < ApplicationController
+  def index
+    @controls = Control.order(:name)
+  end
+end

--- a/app/controllers/controls_controller.rb
+++ b/app/controllers/controls_controller.rb
@@ -6,4 +6,23 @@ class ControlsController < ApplicationController
   def show
     @control = Control.find(params[:id])
   end
+
+  def new
+    @control = Control.new
+  end
+
+  def create
+    @control = Control.new(control_params)
+    if @control.save
+      redirect_to @control, notice: "Control created successfully"
+    else
+      render "new"
+    end
+  end
+
+private
+
+  def control_params
+    params.require(:control).permit(:name, :active, :boost_amount, :filter)
+  end
 end

--- a/app/controllers/controls_controller.rb
+++ b/app/controllers/controls_controller.rb
@@ -20,6 +20,19 @@ class ControlsController < ApplicationController
     end
   end
 
+  def edit
+    @control = Control.find(params[:id])
+  end
+
+  def update
+    @control = Control.find(params[:id])
+    if @control.update(control_params)
+      redirect_to @control, notice: "Control updated successfully"
+    else
+      render "edit"
+    end
+  end
+
 private
 
   def control_params

--- a/app/controllers/controls_controller.rb
+++ b/app/controllers/controls_controller.rb
@@ -33,6 +33,16 @@ class ControlsController < ApplicationController
     end
   end
 
+  def destroy
+    @control = Control.find(params[:id])
+
+    if @control.destroy
+      redirect_to controls_path, notice: "Control deleted successfully"
+    else
+      redirect_to @control, alert: "Control could not be deleted. Try again later."
+    end
+  end
+
 private
 
   def control_params

--- a/app/controllers/controls_controller.rb
+++ b/app/controllers/controls_controller.rb
@@ -2,4 +2,8 @@ class ControlsController < ApplicationController
   def index
     @controls = Control.order(:name)
   end
+
+  def show
+    @control = Control.find(params[:id])
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,11 @@ module ApplicationHelper
         active: controller.controller_name == "recommended_links",
       },
       {
+        text: "Controls",
+        href: controls_path,
+        active: controller.controller_name == "controls",
+      },
+      {
         text: current_user.name,
         href: Plek.new.external_url_for("signon"),
       },

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,4 +23,8 @@ module ApplicationHelper
       },
     ]
   end
+
+  def value_or_not_set(value)
+    value.presence || tag.span("Not set", class: "govuk-hint")
+  end
 end

--- a/app/models/control.rb
+++ b/app/models/control.rb
@@ -1,0 +1,6 @@
+class Control < ApplicationRecord
+  validates :name, presence: true
+  validates :boost_amount, numericality: {
+    greater_than_or_equal_to: -1.0, less_than_or_equal_to: 1.0
+  }
+end

--- a/app/views/controls/_form.html.erb
+++ b/app/views/controls/_form.html.erb
@@ -1,0 +1,59 @@
+<%= form_for(control) do |f| %>
+  <% if control.errors.any? %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      id: "error-summary",
+      title: "There is a problem",
+      description: "The control could not be updated because some fields are missing or incorrect.",
+      items: error_summary_items(control)
+    } %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: Control.human_attribute_name(:name)
+    },
+    id: "control_name",
+    name: "control[name]",
+    value: control.name,
+    error_items: error_items(control, :name)
+  } %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: Control.human_attribute_name(:boost_amount)
+    },
+    hint: "A value between -1.0 and 1.0 used to influence the order of search results.",
+    id: "control_boost_amount",
+    name: "control[boost_amount]",
+    value: control.boost_amount,
+    error_items: error_items(control, :boost_amount)
+  } %>
+
+  <%= render "govuk_publishing_components/components/textarea", {
+    label: {
+      text: Control.human_attribute_name(:filter)
+    },
+    hint: "Determines which documents are affected by this control. See #{link_to 'Vertex AI Search filter syntax', 'https://cloud.google.com/retail/docs/filter-and-order#filter', class: 'govuk-link'} for details.".html_safe,
+    id: "control_filter",
+    name: "control[filter]",
+    value: control.filter,
+    error_items: error_items(control, :filter)
+  } %>
+
+  <%= hidden_field_tag "control[active]", "0" %>
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "control[active]",
+    items: [
+      {
+        label: Control.human_attribute_name(:active),
+        hint: "Controls that are not active will not affect search results.",
+        value: "1",
+        checked: control.active?
+      }
+    ]
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Save"
+  } %>
+<% end %>

--- a/app/views/controls/edit.html.erb
+++ b/app/views/controls/edit.html.erb
@@ -1,0 +1,19 @@
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: "Controls",
+      url: controls_path
+    },
+    {
+      title: @control.display_name,
+      url: control_path(@control)
+    },
+    {
+      title: "Edit"
+    }
+  ]
+} %>
+
+<%= render "common/page_title", title: @control.display_name %>
+
+<%= render "form", control: @control %>

--- a/app/views/controls/index.html.erb
+++ b/app/views/controls/index.html.erb
@@ -1,0 +1,29 @@
+<%= render "common/page_title", title: "Controls" %>
+
+<div class="govuk-!-margin-top-6 app-table__container" data-module="filterable-table">
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Filter controls"
+    },
+    name: "table-filter",
+    type: "search",
+    search_icon: true,
+    tabindex: 0
+  } %>
+  <div class="external-links">
+    <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self) do |t| %>
+      <%= t.head do %>
+        <%= t.header "Name" %>
+        <%= t.header "Active" %>
+      <% end %>
+      <%= t.body do %>
+        <% @controls.each do |control| %>
+          <%= t.row do %>
+            <%= t.cell link_to(control.name, control_path(control), class:'govuk-link') %>
+            <%= t.cell control.active? ? "Yes" : "No" %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/controls/index.html.erb
+++ b/app/views/controls/index.html.erb
@@ -1,5 +1,13 @@
 <%= render "common/page_title", title: "Controls" %>
 
+<div class="actions">
+  <%= render "govuk_publishing_components/components/button", {
+    text: "New control",
+    href: new_control_path,
+    inline_layout: true
+  } %>
+</div>
+
 <div class="govuk-!-margin-top-6 app-table__container" data-module="filterable-table">
   <%= render "govuk_publishing_components/components/input", {
     label: {

--- a/app/views/controls/new.html.erb
+++ b/app/views/controls/new.html.erb
@@ -1,0 +1,15 @@
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: "Controls",
+      url: controls_path
+    },
+    {
+      title: "New control"
+    }
+  ]
+} %>
+
+<%= render "common/page_title", title: "New control" %>
+
+<%= render "form", control: @control %>

--- a/app/views/controls/show.html.erb
+++ b/app/views/controls/show.html.erb
@@ -12,6 +12,14 @@
 
 <%= render "common/page_title", title: @control.name %>
 
+<div class="actions">
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Edit control",
+    href: edit_control_path(@control),
+    inline_layout: true
+  } %>
+</div>
+
 <%= render "govuk_publishing_components/components/summary_list", {
   items: [
     {

--- a/app/views/controls/show.html.erb
+++ b/app/views/controls/show.html.erb
@@ -1,0 +1,38 @@
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: "Controls",
+      url: controls_path
+    },
+    {
+      title: @control.name,
+    }
+  ]
+} %>
+
+<%= render "common/page_title", title: @control.name %>
+
+<%= render "govuk_publishing_components/components/summary_list", {
+  items: [
+    {
+      field: Control.human_attribute_name(:active),
+      value: @control.active? ? "Yes" : "No"
+    },
+    {
+      field: Control.human_attribute_name(:boost_amount),
+      value: value_or_not_set(@control.boost_amount)
+    },
+    {
+      field: Control.human_attribute_name(:filter),
+      value: value_or_not_set(@control.filter)
+    },
+    {
+      field: Control.human_attribute_name(:created_at),
+      value: @control.created_at.to_formatted_s(:govuk_date)
+    },
+    {
+      field: Control.human_attribute_name(:updated_at),
+      value: @control.updated_at.to_formatted_s(:govuk_date)
+    }
+  ]
+} %>

--- a/app/views/controls/show.html.erb
+++ b/app/views/controls/show.html.erb
@@ -18,6 +18,7 @@
     href: edit_control_path(@control),
     inline_layout: true
   } %>
+  <%= delete_button "Delete control", control_path(@control), is_inline: true %>
 </div>
 
 <%= render "govuk_publishing_components/components/summary_list", {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,10 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  activerecord:
+    attributes:
+      control:
+        name: Name
+        boost_amount: Boost amount
+        filter: Filter expression
+        active: Activate control

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,3 +37,5 @@ en:
         boost_amount: Boost amount
         filter: Filter expression
         active: Activate control
+        created_at: Created
+        updated_at: Updated

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   )
 
   resources :recommended_links, path: "/recommended-links"
+  resources :controls
 
   root "recommended_links#index"
 

--- a/db/migrate/20240619100722_create_controls.rb
+++ b/db/migrate/20240619100722_create_controls.rb
@@ -1,0 +1,12 @@
+class CreateControls < ActiveRecord::Migration[7.1]
+  def change
+    create_table :controls do |t|
+      t.string :name
+      t.float :boost_amount
+      t.text :filter
+      t.boolean :active
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_11_142717) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_19_100722) do
+  create_table "controls", charset: "utf8mb3", force: :cascade do |t|
+    t.string "name"
+    t.float "boost_amount"
+    t.text "filter"
+    t.boolean "active"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "recommended_links", charset: "utf8mb3", force: :cascade do |t|
     t.string "title"
     t.string "link"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,11 @@
 FactoryBot.define do
+  factory :control do
+    name { "Control" }
+    boost_amount { 0.5 }
+    filter { 'document_type: ANY("press_release")' }
+    active { true }
+  end
+
   factory :recommended_link do
     title { "Tax online" }
     link { "https://www.tax.service.gov.uk/" }

--- a/spec/models/control_spec.rb
+++ b/spec/models/control_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Control, type: :model do
+  let(:control) { build(:control) }
+
+  describe "validations" do
+    describe "boost_amount" do
+      it "accepts valid values" do
+        control.boost_amount = 0.5
+        expect(control).to be_valid
+      end
+
+      it "refuses too low values" do
+        control.boost_amount = -1.1
+        expect(control).not_to be_valid
+      end
+
+      it "refuses too high values" do
+        control.boost_amount = 1.1
+        expect(control).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/system/controls_spec.rb
+++ b/spec/system/controls_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe "Controls" do
+  scenario "Viewing controls" do
+    given_several_controls
+
+    when_i_visit_the_controls_page
+
+    then_all_controls_are_displayed
+  end
+
+  def given_several_controls
+    @control1 = create(:control, name: "Control 1")
+    @control2 = create(:control, name: "Control 2")
+  end
+
+  def when_i_visit_the_controls_page
+    visit "/"
+    click_on "Controls"
+  end
+
+  def then_all_controls_are_displayed
+    expect(page).to have_link("Control 1")
+    expect(page).to have_link("Control 2")
+  end
+end

--- a/spec/system/controls_spec.rb
+++ b/spec/system/controls_spec.rb
@@ -7,9 +7,27 @@ RSpec.describe "Controls" do
     then_all_controls_are_displayed
   end
 
+  scenario "Viewing a single control" do
+    given_a_control
+
+    when_i_go_to_view_the_control
+
+    then_i_can_see_the_details_of_the_control
+  end
+
   def given_several_controls
     @control1 = create(:control, name: "Control 1")
     @control2 = create(:control, name: "Control 2")
+  end
+
+  def given_a_control
+    @control = create(
+      :control,
+      name: "Control",
+      active: true,
+      boost_amount: 0.42,
+      filter: 'foo: ANY("bar")',
+    )
   end
 
   def when_i_visit_the_controls_page
@@ -17,8 +35,17 @@ RSpec.describe "Controls" do
     click_on "Controls"
   end
 
+  def when_i_go_to_view_the_control
+    visit controls_path
+    click_on "Control"
+  end
+
   def then_all_controls_are_displayed
     expect(page).to have_link("Control 1")
     expect(page).to have_link("Control 2")
+  end
+
+  def then_i_can_see_the_details_of_the_control
+    expect(page).to have_selector("h1", text: "Control")
   end
 end

--- a/spec/system/controls_spec.rb
+++ b/spec/system/controls_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe "Controls" do
     and_i_can_see_what_errors_i_need_to_fix
   end
 
+  scenario "Deleting an existing control" do
+    given_a_control
+
+    when_i_go_to_view_the_control
+    and_i_choose_to_delete_it
+
+    then_the_control_has_been_deleted_locally
+    and_i_am_notified_of_the_deletion
+  end
+
   def given_several_controls
     @control1 = create(:control, name: "Control 1")
     @control2 = create(:control, name: "Control 2")
@@ -109,6 +119,10 @@ RSpec.describe "Controls" do
     click_on "Save"
   end
 
+  def and_i_choose_to_delete_it
+    click_on "Delete"
+  end
+
   def then_the_control_has_not_been_created
     expect(Control.count).to eq(0)
   end
@@ -145,5 +159,13 @@ RSpec.describe "Controls" do
 
   def then_the_control_has_not_been_updated
     expect(@control.reload.display_name).to eq("Control")
+  end
+
+  def then_the_control_has_been_deleted_locally
+    expect(Control.count).to eq(0)
+  end
+
+  def and_i_am_notified_of_the_deletion
+    expect(page).to have_content("Control deleted successfully")
   end
 end

--- a/spec/system/controls_spec.rb
+++ b/spec/system/controls_spec.rb
@@ -33,6 +33,28 @@ RSpec.describe "Controls" do
     and_i_can_see_what_errors_i_need_to_fix
   end
 
+  scenario "Editing an existing control" do
+    given_a_control
+
+    when_i_go_to_view_the_control
+    and_i_choose_to_edit_it
+    and_i_submit_the_form_with_updated_details
+
+    then_the_control_has_been_updated
+    and_i_can_see_the_new_details
+  end
+
+  scenario "Attempting to edit a control with invalid data" do
+    given_a_control
+
+    when_i_go_to_view_the_control
+    and_i_choose_to_edit_it
+    and_i_submit_the_form_with_invalid_details
+
+    then_the_control_has_not_been_updated
+    and_i_can_see_what_errors_i_need_to_fix
+  end
+
   def given_several_controls
     @control1 = create(:control, name: "Control 1")
     @control2 = create(:control, name: "Control 2")
@@ -78,6 +100,15 @@ RSpec.describe "Controls" do
     click_on "Save"
   end
 
+  def and_i_choose_to_edit_it
+    click_on "Edit"
+  end
+
+  def and_i_submit_the_form_with_updated_details
+    fill_in "Name", with: "Updated control"
+    click_on "Save"
+  end
+
   def then_the_control_has_not_been_created
     expect(Control.count).to eq(0)
   end
@@ -102,5 +133,17 @@ RSpec.describe "Controls" do
 
   def and_i_can_see_its_details
     expect(page).to have_selector("h1", text: "New control")
+  end
+
+  def then_the_control_has_been_updated
+    expect(@control.reload.display_name).to eq("Updated control")
+  end
+
+  def and_i_can_see_the_new_details
+    expect(page).to have_selector("h1", text: "Updated control")
+  end
+
+  def then_the_control_has_not_been_updated
+    expect(@control.reload.display_name).to eq("Control")
   end
 end

--- a/spec/system/controls_spec.rb
+++ b/spec/system/controls_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe "Controls" do
     then_i_can_see_the_details_of_the_control
   end
 
+  scenario "Creating a new control" do
+    when_i_visit_the_controls_page
+    and_i_choose_to_create_a_new_control
+    and_i_submit_the_form_with_valid_details
+
+    then_the_control_has_been_created
+    and_i_can_see_its_details
+  end
+
+  scenario "Attempting to create a control with invalid data" do
+    when_i_visit_the_controls_page
+    and_i_choose_to_create_a_new_control
+    and_i_submit_the_form_with_invalid_details
+
+    then_the_control_has_not_been_created
+    and_i_can_see_what_errors_i_need_to_fix
+  end
+
   def given_several_controls
     @control1 = create(:control, name: "Control 1")
     @control2 = create(:control, name: "Control 2")
@@ -40,6 +58,35 @@ RSpec.describe "Controls" do
     click_on "Control"
   end
 
+  def and_i_choose_to_create_a_new_control
+    click_on "New control"
+  end
+
+  def and_i_submit_the_form_with_valid_details
+    fill_in "Name", with: "New control"
+    fill_in "Boost amount", with: 0.42
+    fill_in "Filter", with: 'foo: ANY("bar")'
+    check "Activate control"
+    click_on "Save"
+  end
+
+  def and_i_submit_the_form_with_invalid_details
+    fill_in "Name", with: ""
+    fill_in "Boost amount", with: 42.0
+    fill_in "Filter", with: 'foo: ANY("bar")'
+    check "Activate control"
+    click_on "Save"
+  end
+
+  def then_the_control_has_not_been_created
+    expect(Control.count).to eq(0)
+  end
+
+  def and_i_can_see_what_errors_i_need_to_fix
+    expect(page).to have_content("Name can't be blank")
+    expect(page).to have_content("Boost amount must be less than or equal to 1.0")
+  end
+
   def then_all_controls_are_displayed
     expect(page).to have_link("Control 1")
     expect(page).to have_link("Control 2")
@@ -47,5 +94,13 @@ RSpec.describe "Controls" do
 
   def then_i_can_see_the_details_of_the_control
     expect(page).to have_selector("h1", text: "Control")
+  end
+
+  def then_the_control_has_been_created
+    expect(Control.count).to eq(1)
+  end
+
+  def and_i_can_see_its_details
+    expect(page).to have_selector("h1", text: "New control")
   end
 end


### PR DESCRIPTION
**This adds a basic CRUD scaffold for controls.**

Controls are rulesets defined in Search Admin (and eventually synchronised to Discovery Engine/Vertex AI Search in a future change) that allow us to override the results returned.

In theory, these controls can be quite complex, but our MVP will probably approximate the previous "best bets" functionality where search administrators can promote certain documents to rank higher for a given query ("boosting").

---

<img width="993" alt="image" src="https://github.com/alphagov/search-admin/assets/72141/c16fae7e-9ca2-4bcf-8169-461ab4f0b649">

---

<img width="993" alt="image" src="https://github.com/alphagov/search-admin/assets/72141/b8c80c1e-33f2-41db-b552-ea71591f6a26">

---

<img width="993" alt="image" src="https://github.com/alphagov/search-admin/assets/72141/d4722758-8c74-4173-8956-dcf570c0ed91">