### PR TITLE
Remove legacy `govuk_admin_template` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem "sprockets-rails"
 # GDS managed gems
 gem "gds-api-adapters"
 gem "gds-sso"
-gem "govuk_admin_template"
 gem "govuk_app_config"
 gem "govuk_publishing_components"
 gem "govuk_sidekiq"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,15 +78,10 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
-    autoprefixer-rails (10.4.16.0)
-      execjs (~> 2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
-    bootstrap-sass (3.4.1)
-      autoprefixer-rails (>= 5.2.1)
-      sassc (>= 2.0.0)
     brakeman (6.1.2)
       racc
     builder (3.3.0)
@@ -117,7 +112,6 @@ GEM
     domain_name (0.6.20240107)
     drb (2.2.1)
     erubi (1.13.0)
-    execjs (2.9.1)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -153,11 +147,6 @@ GEM
       rake (>= 13)
     googleapis-common-protos-types (1.15.0)
       google-protobuf (>= 3.18, < 5.a)
-    govuk_admin_template (7.0.0)
-      bootstrap-sass (~> 3.4)
-      jquery-rails (~> 4.3)
-      plek (>= 2.1)
-      rails (>= 6)
     govuk_app_config (9.13.1)
       logstasher (~> 2.1)
       opentelemetry-exporter-otlp (>= 0.25, < 0.29)
@@ -207,10 +196,6 @@ GEM
     irb (1.14.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jquery-rails (4.6.0)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (2.7.2)
     json-schema (4.3.0)
       addressable (>= 2.8)
@@ -625,8 +610,6 @@ GEM
     sass-embedded (1.77.5)
       google-protobuf (>= 3.25, < 5.0)
       rake (>= 13)
-    sassc (2.4.0)
-      ffi (~> 1.9)
     selenium-webdriver (4.21.1)
       base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
@@ -699,7 +682,6 @@ DEPENDENCIES
   foreman
   gds-api-adapters
   gds-sso
-  govuk_admin_template
   govuk_app_config
   govuk_publishing_components
   govuk_schemas

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,4 @@ Rails.application.routes.draw do
   resources :recommended_links, path: "/recommended-links"
 
   root "recommended_links#index"
-
-  mount GovukAdminTemplate::Engine, at: "/style-guide"
 end


### PR DESCRIPTION
This isn't actually used anywhere anymore, other than its helper being used in `ApplicationMailer` to establish the current GOV.UK environment (which can be replaced with the corresponding method from GOV.UK Publishing Components).