### PR TITLE
Fix Javascript issue with Publishing Components v40

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,2 @@
 //= link_tree ../builds
-//= link application.js
-//= link es6-components.js
+//= link_directory ../javascripts .js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,1 @@
-// This file is required to exist by GOV.UK Publishing Components `layout_for_admin` component but
-// currently doesn't need to contain any code. See `es6-components.js` where component JS is
-// included.
+//= require govuk_publishing_components/dependencies

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,4 +1,3 @@
-//= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/error-summary

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,6 +74,10 @@ Rails.application.configure do
   # Ensure latest assets are always available when using Dart SASS in watch mode
   config.assets.digest = false
 
+  # Enable source maps for Javascript and force all non-digested Javascript assets to be served with
+  # non-cache headers
+  config.assets.debug = true
+
   # Force all the stylesheets from the `govuk_publishing_components` gem to be included in Dart Sass
   # builds so we can use the component guide (without this, Sprockets will try and use the legacy
   # SassC compiler to build them which we no longer include in this app)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,3 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
+Rails.application.config.assets.precompile += %w[es6-components.js]


### PR DESCRIPTION
- Move require of Publishing Components dependencies back into `application.js` as recommended by team to fix issue with polyfills
- Make linking in `manifest.js` more generic
- Ensure `es6-components.js` is precompiled
- Set `config.assets.debug` to enable source maps and force additional JS files to be served without caching headers