### PR TITLE
Stop requiring 'gds_api/search', which is no longer used

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,4 +1,3 @@
-require "gds_api/search"
 require "gds_api/publishing_api"
 
 module Services


### PR DESCRIPTION
All associated code was removed in 8d8a372a351ecdd9842525dcbd611450d31de8f6.