### PR TITLE
Remove Sidekiq and Redis

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -22,9 +22,6 @@ jobs:
         id: setup-mysql
         uses: alphagov/govuk-infrastructure/.github/actions/setup-mysql@main
 
-      - name: Setup Redis
-        uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem "bootsnap", require: false
 gem "csv"
 gem "dartsass-rails"
 gem "mysql2"
-gem "sentry-sidekiq"
 gem "sprockets-rails"
 
 # GDS managed gems
@@ -14,7 +13,6 @@ gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_app_config"
 gem "govuk_publishing_components"
-gem "govuk_sidekiq"
 gem "mail-notify"
 gem "plek"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,12 +174,6 @@ GEM
     govuk_schemas (5.0.4)
       faker (~> 3.4.1)
       json-schema (>= 2.8, < 4.4)
-    govuk_sidekiq (8.0.1)
-      gds-api-adapters (>= 19.1.0)
-      govuk_app_config (>= 1.1)
-      redis (< 5)
-      redis-namespace (~> 1.6)
-      sidekiq (~> 6.5, >= 6.5.12)
     govuk_test (4.1.0)
       brakeman (>= 5.0.2)
       capybara (>= 3.36)
@@ -541,9 +535,6 @@ GEM
       ffi (~> 1.0)
     rdoc (6.7.0)
       psych (>= 4.0.0)
-    redis (4.8.1)
-    redis-namespace (1.11.0)
-      redis (>= 4)
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
@@ -621,13 +612,6 @@ GEM
     sentry-ruby (5.18.2)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.18.2)
-      sentry-ruby (~> 5.18.2)
-      sidekiq (>= 3.0)
-    sidekiq (6.5.12)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -685,7 +669,6 @@ DEPENDENCIES
   govuk_app_config
   govuk_publishing_components
   govuk_schemas
-  govuk_sidekiq
   govuk_test
   listen
   mail-notify
@@ -695,7 +678,6 @@ DEPENDENCIES
   rails (= 7.1.3.4)
   rspec-rails
   rubocop-govuk
-  sentry-sidekiq
   simplecov
   sprockets-rails
   webmock

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,2 @@
 web: bin/rails server --restart
-worker: bundle exec sidekiq -C ./config/sidekiq.yml
 css: bin/rails dartsass:watch

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,0 @@
-# govuk-helm-charts expects a sidekiq.yml file to be present in the config directory (unless
-# manually overriding the default `worker` command) and will fail to run workers without one


### PR DESCRIPTION
This app sets up Sidekiq/Redis and runs a worker, but there are no jobs to be run on those workers.

Therefore we can remove the `govuk_sidekiq` gem and the code which sets up the worker processes.

The configuration was updated in https://github.com/alphagov/govuk-helm-charts/pull/2613 to remove the Redis/Sidekiq setup for this app, so we no longer need the `sidekiq.yml` file here.