### PR TITLE
Recommended links spring clean

### DIFF
--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -1,4 +1,6 @@
 class RecommendedLinksController < ApplicationController
+  before_action :set_recommended_link, only: %i[show edit update destroy]
+
   def index
     @recommended_links = RecommendedLink.order([:link])
 
@@ -25,17 +27,12 @@ class RecommendedLinksController < ApplicationController
   end
 
   def show
-    @recommended_link = find_recommended_link
     @search_url = SearchUrl.for(@recommended_link.title)
   end
 
-  def edit
-    @recommended_link = find_recommended_link
-  end
+  def edit; end
 
   def update
-    @recommended_link = find_recommended_link
-
     if @recommended_link.update(update_recommended_link_params)
       ExternalContentPublisher.publish(@recommended_link)
 
@@ -46,21 +43,19 @@ class RecommendedLinksController < ApplicationController
   end
 
   def destroy
-    recommended_link = find_recommended_link
-
-    if recommended_link.destroy
-      ExternalContentPublisher.unpublish(recommended_link)
+    if @recommended_link.destroy
+      ExternalContentPublisher.unpublish(@recommended_link)
 
       redirect_to recommended_links_path, notice: "Your external link was deleted successfully"
     else
-      redirect_to recommended_link_path(recommended_link), alert: "We could not delete your external link"
+      redirect_to recommended_link_path(@recommended_link), alert: "We could not delete your external link"
     end
   end
 
 private
 
-  def find_recommended_link
-    @find_recommended_link ||= RecommendedLink.find(params[:id])
+  def set_recommended_link
+    @recommended_link = RecommendedLink.find(params.expect(:id))
   end
 
   def create_recommended_link_params

--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -63,10 +63,4 @@ private
       .expect(recommended_link: %i[link title description keywords comment])
       .merge(user_id: current_user.id)
   end
-
-  def check_for_duplicate_recommended_link(recommended_link)
-    if recommended_link.errors.include?(:recommended_link)
-      RecommendedLink.where(link: recommended_link.link).first
-    end
-  end
 end

--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -15,7 +15,7 @@ class RecommendedLinksController < ApplicationController
   end
 
   def create
-    @recommended_link = RecommendedLink.new(create_recommended_link_params)
+    @recommended_link = RecommendedLink.new(recommended_link_params)
 
     if @recommended_link.save
       ExternalContentPublisher.publish(@recommended_link)
@@ -33,7 +33,7 @@ class RecommendedLinksController < ApplicationController
   def edit; end
 
   def update
-    if @recommended_link.update(update_recommended_link_params)
+    if @recommended_link.update(recommended_link_params)
       ExternalContentPublisher.publish(@recommended_link)
 
       redirect_to recommended_link_path(@recommended_link), notice: "Your external link was updated successfully"
@@ -58,15 +58,9 @@ private
     @recommended_link = RecommendedLink.find(params.expect(:id))
   end
 
-  def create_recommended_link_params
-    params.require(:recommended_link)
-      .permit(:link, :title, :description, :keywords, :comment)
-      .merge(user_id: current_user.id)
-  end
-
-  def update_recommended_link_params
-    params.require(:recommended_link)
-      .permit(:link, :title, :description, :keywords, :comment)
+  def recommended_link_params
+    params
+      .expect(recommended_link: %i[link title description keywords comment])
       .merge(user_id: current_user.id)
   end
 

--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -26,9 +26,7 @@ class RecommendedLinksController < ApplicationController
     end
   end
 
-  def show
-    @search_url = SearchUrl.for(@recommended_link.title)
-  end
+  def show; end
 
   def edit; end
 

--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -20,7 +20,7 @@ class RecommendedLinksController < ApplicationController
     if @recommended_link.save
       ExternalContentPublisher.publish(@recommended_link)
 
-      redirect_to recommended_link_path(@recommended_link), notice: "Your external link was created successfully"
+      redirect_to recommended_link_path(@recommended_link), notice: t(".success")
     else
       render :new
     end
@@ -36,7 +36,7 @@ class RecommendedLinksController < ApplicationController
     if @recommended_link.update(recommended_link_params)
       ExternalContentPublisher.publish(@recommended_link)
 
-      redirect_to recommended_link_path(@recommended_link), notice: "Your external link was updated successfully"
+      redirect_to recommended_link_path(@recommended_link), notice: t(".success")
     else
       render :edit
     end
@@ -46,9 +46,9 @@ class RecommendedLinksController < ApplicationController
     if @recommended_link.destroy
       ExternalContentPublisher.unpublish(@recommended_link)
 
-      redirect_to recommended_links_path, notice: "Your external link was deleted successfully"
+      redirect_to recommended_links_path, notice: t(".success")
     else
-      redirect_to recommended_link_path(@recommended_link), alert: "We could not delete your external link"
+      redirect_to recommended_link_path(@recommended_link), alert: t(".failure")
     end
   end
 

--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -11,7 +11,7 @@ class RecommendedLinksController < ApplicationController
   end
 
   def new
-    @recommended_link = RecommendedLink.new(content_id: SecureRandom.uuid)
+    @recommended_link = RecommendedLink.new
   end
 
   def create
@@ -61,7 +61,7 @@ private
   def create_recommended_link_params
     params.require(:recommended_link)
       .permit(:link, :title, :description, :keywords, :comment)
-      .merge(user_id: current_user.id, content_id: SecureRandom.uuid)
+      .merge(user_id: current_user.id)
   end
 
   def update_recommended_link_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
 
     [
       {
-        text: "External links",
+        text: t("recommended_links.index.page_title"),
         href: recommended_links_path,
         active: controller.controller_name == "recommended_links",
       },

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
         href: Plek.new.external_url_for("signon"),
       },
       {
-        text: "Sign out",
+        text: t("common.menu.sign_out"),
         href: "/auth/gds/sign_out",
       },
     ]

--- a/app/helpers/model_translation_helper.rb
+++ b/app/helpers/model_translation_helper.rb
@@ -1,0 +1,19 @@
+# Provides more concise helper methods for translating model names and attributes, assuming that the
+# current controller is named after the model it is managing.
+module ModelTranslationHelper
+  # Returns the translated model name for the current controller.
+  def t_model_name(count: 1)
+    inferred_model_class.model_name.human(count:)
+  end
+
+  # Returns the translated name for the given attribute on the current controller's model.
+  def t_model_attr(attr)
+    inferred_model_class.human_attribute_name(attr)
+  end
+
+private
+
+  def inferred_model_class
+    @inferred_model_class ||= controller.controller_name.classify.constantize
+  end
+end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,12 @@
+module SearchHelper
+  def search_url_for_keyword(keyword)
+    query_params = {
+      order: "relevance",
+      debug_score: 1,
+      cachebust: SecureRandom.hex(10),
+      keywords: keyword,
+    }
+
+    URI.join(Plek.new.website_root, "/search/all?#{query_params.to_query}").to_s
+  end
+end

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -1,7 +1,0 @@
-module TagHelper
-  # Set the page <title> and return the <h1> tag.
-  def page_title(string)
-    content_for :page_title, "#{string} - Search Admin"
-    tag.h1 string, class: "page-title-with-border"
-  end
-end

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -1,0 +1,34 @@
+# Allows generating a CSV report from a scope on a model.
+#
+# Use `csv_fields` to specify which attributes to include in the report after including the concern.
+module CsvExportable
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :csv_exportable_attributes
+    self.csv_exportable_attributes = []
+  end
+
+  class_methods do
+    def to_csv
+      CSV.generate(
+        write_headers: true,
+        headers: csv_headers,
+      ) do |csv|
+        find_each do |record|
+          csv << record.attributes.values_at(*csv_exportable_attributes)
+        end
+      end
+    end
+
+  private
+
+    def csv_fields(*attributes)
+      self.csv_exportable_attributes += attributes.map(&:to_s)
+    end
+
+    def csv_headers
+      csv_exportable_attributes.map { human_attribute_name(it) }
+    end
+  end
+end

--- a/app/models/recommended_link.rb
+++ b/app/models/recommended_link.rb
@@ -1,36 +1,12 @@
 class RecommendedLink < ApplicationRecord
+  include CsvExportable
+  csv_fields :title, :link, :description, :keywords, :comment
+
   before_validation :generate_content_id, on: :create
 
   validates :title, :link, :description, :content_id, presence: true
   validates :link, uniqueness: { case_sensitive: true }, url: true
   validates :content_id, uniqueness: { case_sensitive: true }
-
-  def format
-    uri = URI(link)
-    if uri.scheme.nil?
-      uri = URI("https://#{link}")
-    end
-
-    if uri.host.casecmp("www.gov.uk").zero?
-      "inside-government-link"
-    else
-      "recommended-link"
-    end
-  end
-
-  def self.to_csv(*_args)
-    CSV.generate do |csv|
-      csv << %w[title link description keywords comment]
-
-      all.find_each do |link|
-        csv << [link.title,
-                link.link,
-                link.description,
-                link.keywords,
-                link.comment.to_s]
-      end
-    end
-  end
 
 private
 

--- a/app/models/recommended_link.rb
+++ b/app/models/recommended_link.rb
@@ -1,4 +1,6 @@
 class RecommendedLink < ApplicationRecord
+  before_validation :generate_content_id, on: :create
+
   validates :title, :link, :description, :content_id, presence: true
   validates :link, uniqueness: { case_sensitive: true }, url: true
   validates :content_id, uniqueness: { case_sensitive: true }
@@ -28,5 +30,11 @@ class RecommendedLink < ApplicationRecord
                 link.comment.to_s]
       end
     end
+  end
+
+private
+
+  def generate_content_id
+    self.content_id = SecureRandom.uuid
   end
 end

--- a/app/services/search_url.rb
+++ b/app/services/search_url.rb
@@ -1,8 +1,0 @@
-class SearchUrl
-  def self.for(search_term)
-    base_url = Plek.new.website_root
-    search_term = CGI.escape(search_term)
-    random = SecureRandom.hex(10)
-    "#{base_url}/search/all?keywords=#{search_term}&order=relevance&debug_score=1&cachebust=#{random}"
-  end
-end

--- a/app/views/common/_page_title.html.erb
+++ b/app/views/common/_page_title.html.erb
@@ -1,3 +1,4 @@
 <%= render "govuk_publishing_components/components/title", {
   title: title
 } %>
+<% content_for :page_title, title %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,12 +6,12 @@
 
 <%= render "govuk_publishing_components/components/layout_for_admin", {
   environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
-  product_name: "Search Admin",
-  browser_title: yield(:page_title).presence || "Search Admin"
+  product_name: t("common.product_name"),
+  browser_title: yield(:page_title).presence
 } do %>
   <%= render "govuk_publishing_components/components/skip_link" %>
   <%= render "govuk_publishing_components/components/layout_header", {
-    product_name: "Search Admin",
+    product_name: t("common.product_name"),
     environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
     navigation_items: navigation_items
   } %>

--- a/app/views/recommended_links/_form.html.erb
+++ b/app/views/recommended_links/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(recommended_link) do |f| %>
+<%= form_with(model: recommended_link) do |f| %>
   <% if recommended_link.errors.any? %>
     <%= render "govuk_publishing_components/components/error_summary", {
       id: "error-summary",

--- a/app/views/recommended_links/_form.html.erb
+++ b/app/views/recommended_links/_form.html.erb
@@ -2,15 +2,15 @@
   <% if recommended_link.errors.any? %>
     <%= render "govuk_publishing_components/components/error_summary", {
       id: "error-summary",
-      title: "There is a problem",
-      description: "The external link could not be updated because some fields are missing or incorrect.",
+      title: t("common.error_summary.title"),
+      description: t("common.error_summary.description", model_name: t_model_name),
       items: error_summary_items(recommended_link)
     } %>
   <% end %>
 
   <%= render "govuk_publishing_components/components/input", {
     label: {
-      text: 'Link'
+      text: t_model_attr(:link)
     },
     id: "recommended_link_link",
     name: "recommended_link[link]",
@@ -20,7 +20,7 @@
 
   <%= render "govuk_publishing_components/components/input", {
     label: {
-      text: 'Title'
+      text: t_model_attr(:title)
     },
     id: "recommended_link_title",
     name: "recommended_link[title]",
@@ -30,7 +30,7 @@
 
   <%= render "govuk_publishing_components/components/textarea", {
     label: {
-      text: 'Description'
+      text: t_model_attr(:description)
     },
     id: "recommended_link_description",
     name: "recommended_link[description]",
@@ -40,7 +40,7 @@
 
   <%= render "govuk_publishing_components/components/textarea", {
     label: {
-      text: 'Keywords'
+      text: t_model_attr(:keywords)
     },
     name: "recommended_link[keywords]",
     value: recommended_link.keywords
@@ -48,13 +48,13 @@
 
   <%= render "govuk_publishing_components/components/textarea", {
     label: {
-      text: 'Comment'
+      text: t_model_attr(:comment)
     },
     name: "recommended_link[comment]",
     value: recommended_link.comment
   } %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: "Save"
+    text: t("common.buttons.save", model_name: t_model_name),
   } %>
 <% end %>

--- a/app/views/recommended_links/edit.html.erb
+++ b/app/views/recommended_links/edit.html.erb
@@ -5,7 +5,7 @@
       url: recommended_links_path
     },
     {
-      title: @recommended_link.title,
+      title: @recommended_link.title_was,
       url: recommended_link_path(@recommended_link)
     },
     {
@@ -14,6 +14,6 @@
   ]
 } %>
 
-<%= render "common/page_title", title: @recommended_link.title %>
+<%= render "common/page_title", title: @recommended_link.title_was %>
 
 <%= render 'form', recommended_link: @recommended_link %>

--- a/app/views/recommended_links/edit.html.erb
+++ b/app/views/recommended_links/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render "govuk_publishing_components/components/breadcrumbs", {
   breadcrumbs: [
     {
-      title: "External links",
+      title: t("recommended_links.index.page_title"),
       url: recommended_links_path
     },
     {
@@ -9,7 +9,7 @@
       url: recommended_link_path(@recommended_link)
     },
     {
-      title: "Edit"
+      title: t(".page_title")
     }
   ]
 } %>

--- a/app/views/recommended_links/index.html.erb
+++ b/app/views/recommended_links/index.html.erb
@@ -1,13 +1,13 @@
-<%= render "common/page_title", title: "External links" %>
+<%= render "common/page_title", title: t(".page_title") %>
 
 <div class="actions">
   <%= render "govuk_publishing_components/components/button", {
-    text: "New external link",
+    text: t("common.buttons.new", model_name: t_model_name),
     href: new_recommended_link_path,
     inline_layout: true
   } %>
   <%= render "govuk_publishing_components/components/button", {
-    text: "Download CSV",
+    text: t("common.buttons.download_csv"),
     href: recommended_links_path(format: 'csv'),
     secondary_quiet: true,
     inline_layout: true
@@ -18,12 +18,12 @@
   <div class="external-links">
     <%= render "govuk_publishing_components/components/table", {
       filterable: true,
-      label: "Filter external links",
+      label: t(".filter_table_label"),
       head: [
-        { text: "Title" },
-        { text: "Link" },
-        { text: "Description" },
-        { text: "Keywords" },
+        { text: t_model_attr(:title) },
+        { text: t_model_attr(:link) },
+        { text: t_model_attr(:description) },
+        { text: t_model_attr(:keywords) },
       ],
       rows: @recommended_links.map do |recommended_link|
         [

--- a/app/views/recommended_links/new.html.erb
+++ b/app/views/recommended_links/new.html.erb
@@ -1,15 +1,15 @@
 <%= render "govuk_publishing_components/components/breadcrumbs", {
   breadcrumbs: [
     {
-      title: "External links",
+      title: t("recommended_links.index.page_title"),
       url: recommended_links_path
     },
     {
-      title: "New external link"
+      title: t(".page_title")
     }
   ]
 } %>
 
-<%= render "common/page_title", title:"New external link" %>
+<%= render "common/page_title", title: t(".page_title") %>
 
 <%= render 'form', recommended_link: @recommended_link %>

--- a/app/views/recommended_links/show.html.erb
+++ b/app/views/recommended_links/show.html.erb
@@ -50,7 +50,7 @@
 
 <%= render "govuk_publishing_components/components/button", {
   text: t(".view_on_search_button"),
-  href: @search_url,
+  href: search_url_for_keyword(@recommended_link.title),
   target: "_blank",
   secondary_quiet: true
 } %>

--- a/app/views/recommended_links/show.html.erb
+++ b/app/views/recommended_links/show.html.erb
@@ -1,7 +1,7 @@
 <%= render "govuk_publishing_components/components/breadcrumbs", {
   breadcrumbs: [
     {
-      title: "External links",
+      title: t("recommended_links.index.page_title"),
       url: recommended_links_path
     },
     {
@@ -14,15 +14,19 @@
 
 <div class="actions">
   <%= render "govuk_publishing_components/components/button", {
-    text: "Edit external link",
+    text: t("common.buttons.edit", model_name: t_model_name),
     href: edit_recommended_link_path(@recommended_link),
     inline_layout: true
   } %>
-  <%= delete_button "Delete external link", recommended_link_path(@recommended_link), is_inline: true %>
+  <%= delete_button(
+    t("common.buttons.delete", model_name: t_model_name),
+    recommended_link_path(@recommended_link),
+    is_inline: true
+  ) %>
 </div>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: "Preview",
+  text: t(".preview_heading"),
   heading_level: 3,
   font_size: "m",
   padding: true
@@ -45,14 +49,12 @@
 </div>
 
 <%= render "govuk_publishing_components/components/button", {
-  text: "View on GOV.UK Search",
+  text: t(".view_on_search_button"),
   href: @search_url,
   target: "_blank",
   secondary_quiet: true
 } %>
 
 <p class="govuk-body-s govuk-!-margin-top-2">
-  Changes to recommended links may take several minutes to be visible in live search results on
-  GOV.UK. This recommended link may not be the top search result even when searching for its exact
-  title because of the way content is ranked by the search engine.
+  <%= t(".disclaimer") %>
 </p>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,8 @@
 en:
   common:
     product_name: Search Admin
+    menu:
+      sign_out: Sign out
     buttons:
       save: Save %{model_name}
       new: New %{model_name}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,7 @@
 
 en:
   common:
+    product_name: Search Admin
     buttons:
       save: Save %{model_name}
       new: New %{model_name}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,5 +30,53 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
+  common:
+    buttons:
+      save: Save %{model_name}
+      new: New %{model_name}
+      edit: Edit %{model_name}
+      delete: Delete %{model_name}
+      download_csv: Download CSV
+    error_summary:
+      title: There is a problem
+      description: |
+        The %{model_name} could not be saved because some fields are missing or incorrect.
+
   activerecord:
+    models:
+      recommended_link:
+        one: external link
+        other: external links
     attributes:
+      recommended_link:
+        link: Link
+        title: Title
+        description: Description
+        keywords: Keywords
+        comment: Comments
+        created_at: Created at
+        updated_at: Updated at
+
+  recommended_links:
+    index:
+      page_title: External links
+      download_csv_button: Download CSV
+      filter_table_label: Filter external links
+    show:
+      preview_heading: Preview
+      view_on_search_button: View on GOV.UK Search
+      disclaimer: |
+        Changes to recommended links may take several minutes to be visible in live search results
+        on GOV.UK. This recommended link may not be the top search result even when searching for
+        its exact title because of the way content is ranked by the search engine.
+    new:
+      page_title: New external link
+    create:
+      success: The external link was successfully created.
+    edit:
+      page_title: Edit
+    update:
+      success: The external link was successfully updated.
+    destroy:
+      success: The external link was successfully deleted.
+      failure: The external link could not be deleted.

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     link { "https://www.tax.service.gov.uk/" }
     description { "File your self assessment online." }
     keywords { "tax, self assessment, hmrc" }
-    content_id { SecureRandom.uuid }
   end
 
   factory :user do

--- a/spec/models/recommended_link_spec.rb
+++ b/spec/models/recommended_link_spec.rb
@@ -1,4 +1,12 @@
 RSpec.describe RecommendedLink do
+  describe "#content_id" do
+    subject(:recommended_link) { build(:recommended_link) }
+
+    it "is generated on initial create" do
+      expect { recommended_link.save }.to change { recommended_link.content_id }.from(nil)
+    end
+  end
+
   describe "#format" do
     subject(:format) { create(:recommended_link, link:).format }
 

--- a/spec/models/recommended_link_spec.rb
+++ b/spec/models/recommended_link_spec.rb
@@ -7,28 +7,6 @@ RSpec.describe RecommendedLink do
     end
   end
 
-  describe "#format" do
-    subject(:format) { create(:recommended_link, link:).format }
-
-    context "when the link is external to GOV.UK" do
-      let(:link) { "https://www.google.com" }
-
-      it { is_expected.to eq("recommended-link") }
-    end
-
-    context "when the link is internal to GOV.UK" do
-      let(:link) { "https://www.gov.uk/bank-holidays" }
-
-      it { is_expected.to eq("inside-government-link") }
-    end
-
-    context "when the link is external to GOV.UK but has a GOV.UK domain" do
-      let(:link) { "https://www.free-ice-cream.gov.uk" }
-
-      it { is_expected.to eq("recommended-link") }
-    end
-  end
-
   describe "validations" do
     subject(:recommended_link) { build(:recommended_link, link:) }
 

--- a/spec/models/recommended_link_spec.rb
+++ b/spec/models/recommended_link_spec.rb
@@ -1,63 +1,58 @@
 RSpec.describe RecommendedLink do
   describe "#format" do
-    it "uses recommended-link format if it is external to gov.uk" do
-      recommended_link = create(
-        :recommended_link,
-        link: "https://www.google.com",
-      )
-      expect(recommended_link.format).to eq "recommended-link"
+    subject(:format) { create(:recommended_link, link:).format }
+
+    context "when the link is external to GOV.UK" do
+      let(:link) { "https://www.google.com" }
+
+      it { is_expected.to eq("recommended-link") }
     end
 
-    it "uses inside-government-link format if it is internal to gov.uk" do
-      recommended_link = create(
-        :recommended_link,
-        link: "https://www.gov.uk/bank-holidays",
-      )
-      expect(recommended_link.format).to eq "inside-government-link"
+    context "when the link is internal to GOV.UK" do
+      let(:link) { "https://www.gov.uk/bank-holidays" }
+
+      it { is_expected.to eq("inside-government-link") }
     end
 
-    it "uses recommended-link format if it is external to gov.uk but has a gov.uk domain" do
-      recommended_link = create(
-        :recommended_link,
-        link: "https://www.free-ice-cream.gov.uk",
-      )
-      expect(recommended_link.format).to eq "recommended-link"
+    context "when the link is external to GOV.UK but has a GOV.UK domain" do
+      let(:link) { "https://www.free-ice-cream.gov.uk" }
+
+      it { is_expected.to eq("recommended-link") }
     end
   end
 
   describe "validations" do
-    it "is invalid without a title attribute" do
-      attributes = attributes_for(:recommended_link, title: nil)
+    subject(:recommended_link) { build(:recommended_link, link:) }
 
-      expect(new_recommended_link_with(attributes)).not_to be_valid
+    context "with an incomplete link" do
+      let(:link) { "www.hello-world.com" }
+
+      it "is invalid" do
+        expect(recommended_link).not_to be_valid
+        expect(recommended_link.errors.full_messages).to eq(["Link is an invalid URL"])
+      end
     end
 
-    it "is invalid with an incomplete link" do
-      attributes = attributes_for(:recommended_link, link: "www.hello-world.com")
+    context "with a link without a host" do
+      let(:link) { "http:/path-not-host" }
 
-      record = new_recommended_link_with(attributes)
-      expect(record).not_to be_valid
-      expect(record.errors.full_messages).to eq(["Link is an invalid URL"])
+      it "is invalid" do
+        expect(recommended_link).not_to be_valid
+        expect(recommended_link.errors.full_messages).to eq(["Link does not have a valid host"])
+      end
     end
 
-    it "is invalid with a link without a host" do
-      attributes = attributes_for(:recommended_link, link: "http:/path-not-host")
+    context "with a duplicate link" do
+      let(:link) { "https://www.tax.service.gov.uk/" }
 
-      record = new_recommended_link_with(attributes)
-      expect(record).not_to be_valid
-      expect(record.errors.full_messages).to eq(["Link does not have a valid host"])
-    end
+      before do
+        create(:recommended_link, link: link)
+      end
 
-    it "is invalid with a duplicate link" do
-      create(:recommended_link, title: "Tax", link: "https://www.tax.service.gov.uk/", description: "Self assessment", keywords: "self, assessment, tax")
-
-      recommended_link = new_recommended_link_with(title: "Tax", link: "https://www.tax.service.gov.uk/", description: "Self assessment", keywords: "self, assessment, tax")
-
-      expect(recommended_link).to_not be_valid
+      it "is invalid" do
+        expect(recommended_link).not_to be_valid
+        expect(recommended_link.errors.full_messages).to eq(["Link has already been taken"])
+      end
     end
   end
-end
-
-def new_recommended_link_with(attributes)
-  RecommendedLink.new(attributes)
 end

--- a/spec/system/recommended_links_spec.rb
+++ b/spec/system/recommended_links_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe "Recommended links" do
   end
 
   def then_the_link_has_been_deleted_locally
-    expect(page).to have_content("Your external link was deleted successfully")
+    expect(page).to have_content("The external link was successfully deleted")
   end
 
   def and_it_has_been_unpublished

--- a/spec/system/recommended_links_spec.rb
+++ b/spec/system/recommended_links_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe "Recommended links" do
   def and_i_can_choose_to_view_it_on_govuk_search
     expect(page).to have_link(
       "View on GOV.UK Search",
-      href: %r{^https://www\.test\.gov\.uk/search/all\?keywords=Example\+link},
+      href: %r{^https://www\.test\.gov\.uk/search/all\?.+keywords=Example\+link},
     )
   end
 


### PR DESCRIPTION
As part of working on the new result controls feature, I've noticed some more things in the existing recommended links code that either didn't match how the new code worked (e.g. using legacy Rails practices) or could use tidying up.

This PR covers several small assorted refactorings, but also some notable bigger ones:
* Bringing `RecommendedLinksController` up to scratch with current Rails
* Using i18n throughout instead of hardcoded content in views (so we're consistent with upcoming development work)