### PR TITLE
Update calls to textarea with the id option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (49.1.0)
+    govuk_publishing_components (50.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/views/recommended_links/_form.html.erb
+++ b/app/views/recommended_links/_form.html.erb
@@ -32,7 +32,7 @@
     label: {
       text: t_model_attr(:description)
     },
-    id: "recommended_link_description",
+    textarea_id: "recommended_link_description",
     name: "recommended_link[description]",
     value: recommended_link.description,
     error_items: error_items(recommended_link, :description)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Update all uses of the textarea component to change the `id` option to `textarea_id`.

Tests in this PR are likely to fail until the changes to the textarea component are included in this PR with a new gem release.

## Why
Changes in https://github.com/alphagov/govuk_publishing_components/pull/4574 mean that this option needs to be updated.

## Visual changes
Shouldn't be any.

Trello card: https://trello.com/c/GQ1p2oSC/438-not-doing-add-component-wrapper-helper-to-form-textarea-component