### PR TITLE
Add ability to manage adjustments

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -13,6 +13,11 @@ on:
         default: main
         type: string
 
+env:
+  DISCOVERY_ENGINE_DATASTORE: not-used
+  DISCOVERY_ENGINE_ENGINE: not-used
+  DISCOVERY_ENGINE_SERVING_CONFIG: not-used
+
 jobs:
   run-rspec:
     name: Run RSpec

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "rails", "8.0.1"
 gem "bootsnap", require: false
 gem "csv"
 gem "dartsass-rails"
+gem "google-cloud-discovery_engine"
 gem "mysql2"
 gem "sprockets-rails"
 
@@ -24,6 +25,7 @@ group :test do
   gem "factory_bot_rails"
   gem "govuk_schemas"
   gem "govuk_test"
+  gem "grpc_mock"
   gem "simplecov"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,8 +123,20 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
+    faraday-retry (2.2.1)
+      faraday (~> 2.0)
     ffi (1.17.1)
     foreman (0.88.1)
+    gapic-common (0.24.0)
+      faraday (>= 1.9, < 3.a)
+      faraday-retry (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.2)
+      google-logging-utils (~> 0.1)
+      google-protobuf (>= 3.25, < 5.a)
+      googleapis-common-protos (~> 1.6)
+      googleapis-common-protos-types (~> 1.15)
+      googleauth (~> 1.12)
+      grpc (~> 1.66)
     gds-api-adapters (98.2.0)
       addressable
       link_header
@@ -142,11 +154,45 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-cloud-core (1.7.1)
+      google-cloud-env (>= 1.0, < 3.a)
+      google-cloud-errors (~> 1.0)
+    google-cloud-discovery_engine (1.1.0)
+      google-cloud-core (~> 1.6)
+      google-cloud-discovery_engine-v1 (~> 1.1)
+      google-cloud-discovery_engine-v1beta (>= 0.15, < 2.a)
+    google-cloud-discovery_engine-v1 (1.4.0)
+      gapic-common (>= 0.24.0, < 2.a)
+      google-cloud-errors (~> 1.0)
+      google-cloud-location (>= 0.7, < 2.a)
+    google-cloud-discovery_engine-v1beta (0.17.0)
+      gapic-common (>= 0.24.0, < 2.a)
+      google-cloud-errors (~> 1.0)
+      google-cloud-location (>= 0.7, < 2.a)
+    google-cloud-env (2.2.1)
+      faraday (>= 1.0, < 3.a)
+    google-cloud-errors (1.4.0)
+    google-cloud-location (0.9.0)
+      gapic-common (>= 0.24.0, < 2.a)
+      google-cloud-errors (~> 1.0)
+    google-logging-utils (0.1.0)
     google-protobuf (4.29.3)
       bigdecimal
       rake (>= 13)
+    googleapis-common-protos (1.6.0)
+      google-protobuf (>= 3.18, < 5.a)
+      googleapis-common-protos-types (~> 1.7)
+      grpc (~> 1.41)
     googleapis-common-protos-types (1.18.0)
       google-protobuf (>= 3.18, < 5.a)
+    googleauth (1.12.2)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.2)
+      google-logging-utils (~> 0.1)
+      jwt (>= 1.4, < 3.0)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (>= 0.16, < 2.a)
     govuk_app_config (9.16.1)
       logstasher (~> 2.1)
       opentelemetry-exporter-otlp (>= 0.25, < 0.30)
@@ -180,6 +226,11 @@ GEM
       capybara (>= 3.36)
       puma
       selenium-webdriver (>= 4.0)
+    grpc (1.69.0)
+      google-protobuf (>= 3.25, < 5.0)
+      googleapis-common-protos-types (~> 1.0)
+    grpc_mock (0.4.6)
+      grpc (>= 1.12.0, < 2)
     hashdiff (1.1.2)
     hashie (5.0.0)
     http-accept (1.7.0)
@@ -234,6 +285,7 @@ GEM
     mini_portile2 (2.8.8)
     minitest (5.25.4)
     msgpack (1.7.5)
+    multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mysql2 (0.5.6)
@@ -472,6 +524,7 @@ GEM
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.10.1)
       opentelemetry-api (~> 1.0)
+    os (1.1.4)
     ostruct (0.6.1)
     parallel (1.26.3)
     parser (3.3.7.0)
@@ -623,6 +676,11 @@ GEM
     sentry-ruby (5.22.1)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    signet (0.19.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -680,10 +738,12 @@ DEPENDENCIES
   foreman
   gds-api-adapters
   gds-sso
+  google-cloud-discovery_engine
   govuk_app_config
   govuk_publishing_components
   govuk_schemas
   govuk_test
+  grpc_mock
   listen
   mail-notify
   mysql2

--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -14,7 +14,7 @@ class AdjustmentsController < ApplicationController
   def create
     @adjustment = Adjustment.new(adjustment_params)
 
-    if @adjustment.save
+    if @adjustment.save_and_sync
       redirect_to @adjustment, notice: t(".success")
     else
       render :new, status: :unprocessable_entity
@@ -26,7 +26,9 @@ class AdjustmentsController < ApplicationController
   def edit; end
 
   def update
-    if @adjustment.update(adjustment_params)
+    @adjustment.assign_attributes(adjustment_params)
+
+    if @adjustment.save_and_sync
       redirect_to @adjustment, notice: t(".success")
     else
       render :edit, status: :unprocessable_entity
@@ -34,7 +36,7 @@ class AdjustmentsController < ApplicationController
   end
 
   def destroy
-    if @adjustment.destroy
+    if @adjustment.destroy_and_sync
       redirect_to adjustments_path, notice: t(".success")
     else
       redirect_to @adjustment, alert: t(".failure")

--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -1,5 +1,5 @@
 class AdjustmentsController < ApplicationController
-  before_action :set_adjustment, only: %i[show]
+  before_action :set_adjustment, only: %i[show edit update]
 
   def index
     @adjustments = Adjustment.all
@@ -22,6 +22,16 @@ class AdjustmentsController < ApplicationController
   end
 
   def show; end
+
+  def edit; end
+
+  def update
+    if @adjustment.update(adjustment_params)
+      redirect_to @adjustment, notice: t(".success")
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
 private
 

--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -1,5 +1,5 @@
 class AdjustmentsController < ApplicationController
-  before_action :set_adjustment, only: %i[show edit update]
+  before_action :set_adjustment, only: %i[show edit update destroy]
 
   def index
     @adjustments = Adjustment.all
@@ -30,6 +30,14 @@ class AdjustmentsController < ApplicationController
       redirect_to @adjustment, notice: t(".success")
     else
       render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @adjustment.destroy
+      redirect_to adjustments_path, notice: t(".success")
+    else
+      redirect_to @adjustment, alert: t(".failure")
     end
   end
 

--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -5,11 +5,31 @@ class AdjustmentsController < ApplicationController
     @adjustments = Adjustment.all
   end
 
+  def new
+    redirect_to(adjustments_path) unless Adjustment.kinds.include?(params[:kind])
+
+    @adjustment = Adjustment.new(kind: params[:kind])
+  end
+
+  def create
+    @adjustment = Adjustment.new(adjustment_params)
+
+    if @adjustment.save
+      redirect_to @adjustment, notice: t(".success")
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
   def show; end
 
 private
 
   def set_adjustment
     @adjustment = Adjustment.find(params[:id])
+  end
+
+  def adjustment_params
+    params.expect(adjustment: %i[kind name filter_expression boost_factor])
   end
 end

--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -1,0 +1,15 @@
+class AdjustmentsController < ApplicationController
+  before_action :set_adjustment, only: %i[show]
+
+  def index
+    @adjustments = Adjustment.all
+  end
+
+  def show; end
+
+private
+
+  def set_adjustment
+    @adjustment = Adjustment.find(params[:id])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,11 @@ module ApplicationHelper
         active: controller.controller_name == "recommended_links",
       },
       {
+        text: t("adjustments.index.page_title"),
+        href: adjustments_path,
+        active: controller.controller_name == "adjustments",
+      },
+      {
         text: current_user.name,
         href: Plek.new.external_url_for("signon"),
       },

--- a/app/helpers/model_translation_helper.rb
+++ b/app/helpers/model_translation_helper.rb
@@ -11,6 +11,14 @@ module ModelTranslationHelper
     inferred_model_class.human_attribute_name(attr)
   end
 
+  # Returns a translated enum value for the given attribute on the current controller's model.
+  def t_model_enum_value(attr, value)
+    t(
+      value,
+      scope: "activerecord.attributes.#{inferred_model_class.model_name.i18n_key}.#{attr}_values",
+    )
+  end
+
 private
 
   def inferred_model_class

--- a/app/lib/discovery_engine/error.rb
+++ b/app/lib/discovery_engine/error.rb
@@ -1,0 +1,20 @@
+module DiscoveryEngine
+  # An application-level representation of a Google::Cloud::Error raised by the Discovery Engine API
+  # client.
+  class Error < StandardError
+    # Returns whether the error is likely to be caused by an invalid request/user input, for example
+    # an invalid value provided for a field.
+    def invalid_request?
+      # Unfortunately the Discovery Engine API does not return any helpful error details as of
+      # January 2025, so we just assume that an `InvalidArgumentError` is probably related to
+      # invalid user input.
+      cause.is_a?(Google::Cloud::InvalidArgumentError)
+    end
+
+    # Try to extract the `details` field from the original Discovery Engine error, which may contain
+    # a more helpful description of what happened than our own error messages.
+    def message
+      cause&.details || super
+    end
+  end
+end

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -10,6 +10,9 @@ class Adjustment < ApplicationRecord
   # The range of permissible boost factor values
   BOOST_FACTOR_RANGE = -1.0..1.0
 
+  include DiscoveryEngineSyncable
+  discovery_engine_syncable as: DiscoveryEngine::Control
+
   enum :kind, { filter: 0, boost: 1 }, suffix: true, validate: true
 
   validates :name, presence: true

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -16,4 +16,33 @@ class Adjustment < ApplicationRecord
   validates :filter_expression, presence: true
   validates :boost_factor, numericality: { in: BOOST_FACTOR_RANGE, other_than: 0 }, if: :boost_kind?
   validates :boost_factor, absence: true, unless: :boost_kind?
+
+  # The action attributes for the corresponding `DiscoveryEngine::Control`.
+  def control_action
+    if boost_kind?
+      {
+        boost_action: {
+          boost: boost_factor,
+          filter: filter_expression,
+          data_store: discovery_engine_datastore,
+        },
+      }
+    elsif filter_kind?
+      {
+        filter_action: {
+          filter: filter_expression,
+          data_store: discovery_engine_datastore,
+        },
+      }
+    end
+  end
+
+private
+
+  # The datastore whose documents the corresponding `DiscoveryEngine::Control` will affect. We only
+  # use a single datastore in our architecture, so this will always be the same as set by the app's
+  # configuration.
+  def discovery_engine_datastore
+    Rails.configuration.discovery_engine_datastore
+  end
 end

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -1,0 +1,19 @@
+# Adjustments allow search administrators to override how the search engine ranks results.
+#
+# An adjustment applies to any document that matches its `filter_expression`, and can be one of two kinds:
+#   - `boost`: increases or decreases the rank of matching documents by a given `boost_factor`
+#   - `filter`: removes matching documents from the search results entirely
+#
+# See https://cloud.google.com/generative-ai-app-builder/docs/filter-search-metadata for more
+# information on the `filter_expression` syntax.
+class Adjustment < ApplicationRecord
+  # The range of permissible boost factor values
+  BOOST_FACTOR_RANGE = -1.0..1.0
+
+  enum :kind, { filter: 0, boost: 1 }, suffix: true, validate: true
+
+  validates :name, presence: true
+  validates :filter_expression, presence: true
+  validates :boost_factor, numericality: { in: BOOST_FACTOR_RANGE, other_than: 0 }, if: :boost_kind?
+  validates :boost_factor, absence: true, unless: :boost_kind?
+end

--- a/app/models/concerns/discovery_engine_syncable.rb
+++ b/app/models/concerns/discovery_engine_syncable.rb
@@ -1,0 +1,71 @@
+# Allows a model to be synchronised with a remote resource in Discovery Engine.
+#
+# Use `discovery_engine_syncable as: ResourceClass` to specify which resource class should be used.
+module DiscoveryEngineSyncable
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :discovery_engine_resource_class
+  end
+
+  class_methods do
+    def discovery_engine_syncable(as:)
+      self.discovery_engine_resource_class = as
+    end
+  end
+
+  # Saves the record and creates or updates the corresponding resource in Discovery Engine depending
+  # on whether the record is new. Rolls back in case of error, and adds details of any remote API
+  # errors to the record so they can be displayed to the user.
+  def save_and_sync
+    transaction do
+      return false unless save
+
+      if previously_new_record?
+        resource.create!
+      else
+        resource.update!
+      end
+    end
+  rescue DiscoveryEngine::Error => e
+    handle_error(e)
+    false
+  end
+
+  # Destroys the record and deletes the corresponding resource in Discovery Engine. Rolls back in
+  # case of error, and adds details of any remote API errors to the record so they can be displayed
+  # to the user.
+  def destroy_and_sync
+    transaction do
+      return false unless destroy
+
+      resource.delete!
+    end
+  rescue DiscoveryEngine::Error => e
+    handle_error(e)
+    false
+  end
+
+private
+
+  def handle_error(error)
+    # If the error is about an invalid request, it's likely that the user can do something about it
+    # and try again (for example, where Discovery Engine has stricter validations that we can't
+    # replicate in this app).
+    #
+    # Otherwise, we don't need to show the possibly confusing error message error to the user, but
+    # we should log it for investigation (and ideally the root cause error rather than our custom
+    # wrapper).
+    if error.invalid_request?
+      errors.add(:base, :discovery_engine_invalid_request, message: error.message)
+    else
+      errors.add(:base, :discovery_engine_unrecoverable)
+      Rails.logger.error(error.cause&.message || error.message)
+      GovukError.notify(error.cause || error)
+    end
+  end
+
+  def resource
+    @resource ||= discovery_engine_resource_class.new(self)
+  end
+end

--- a/app/models/discovery_engine/control.rb
+++ b/app/models/discovery_engine/control.rb
@@ -1,0 +1,74 @@
+module DiscoveryEngine
+  # Represents a `Control` resource on Discovery Engine.
+  #
+  # Each control is a single, specific customisation of search engine behaviour that can affect how
+  # a query is processed, or how results are returned.
+  #
+  # Several different models in Search Admin map to Controls in Discovery Engine (such as
+  # `Adjustment`), so this class operates on a duck typed "controllable".
+  #
+  # see
+  # https://cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1/latest/Google-Cloud-DiscoveryEngine-V1-Control
+  class Control
+    def initialize(
+      controllable,
+      client: ::Google::Cloud::DiscoveryEngine.control_service(version: :v1)
+    )
+      @controllable = controllable
+      @client = client
+    end
+
+    # Create a new Control resource on Discovery Engine.
+    def create!
+      client.create_control(control:, control_id: id, parent: parent_name)
+    rescue Google::Cloud::Error => e
+      raise Error, e
+    end
+
+    # Update an existing Control resource on Discovery Engine.
+    def update!
+      client.update_control(control:)
+    rescue Google::Cloud::Error => e
+      raise Error, e
+    end
+
+    # Delete an existing Control resource on Discovery Engine.
+    def delete!
+      client.delete_control(name:)
+    rescue Google::Cloud::Error => e
+      raise Error, e
+    end
+
+    # A unique ID used in Discovery Engine to identify the control. Becomes part of the fully
+    # qualified name after remote creation.
+    def id
+      sprintf("search-admin-%s-%s", controllable.model_name.param_key, controllable.id)
+    end
+
+    # The fully qualified name (path) of the control in Discovery Engine.
+    def name
+      [parent_name, "/controls/", id].join
+    end
+
+  private
+
+    attr_reader :controllable, :client
+
+    # The combined parameters for the Control resource to be created or updated.
+    def control
+      {
+        name:,
+        display_name: controllable.name,
+        **controllable.control_action,
+        solution_type: Google::Cloud::DiscoveryEngine::V1::SolutionType::SOLUTION_TYPE_SEARCH,
+        # Trip hazard: despite the plural name, this expects _one_ use case in an array
+        use_cases: [Google::Cloud::DiscoveryEngine::V1::SearchUseCase::SEARCH_USE_CASE_SEARCH],
+      }
+    end
+
+    # Parent resource of the control, in our case always the main engine.
+    def parent_name
+      Rails.configuration.discovery_engine_engine
+    end
+  end
+end

--- a/app/views/adjustments/_form.html.erb
+++ b/app/views/adjustments/_form.html.erb
@@ -1,0 +1,51 @@
+<%= form_with(model: adjustment) do |f| %>
+  <% if adjustment.errors.any? %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      id: "error-summary",
+      title: t("common.error_summary.title"),
+      description: t("common.error_summary.description", model_name: t_model_name),
+      items: error_summary_items(adjustment)
+    } %>
+  <% end %>
+
+  <%= f.hidden_field :kind %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t_model_attr(:name)
+    },
+    id: "adjustment_name",
+    name: "adjustment[name]",
+    hint: t("helpers.hint.adjustment.name"),
+    value: adjustment.name,
+    error_items: error_items(adjustment, :name)
+  } %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t_model_attr(:filter_expression)
+    },
+    id: "adjustment_filter_expression",
+    name: "adjustment[filter_expression]",
+    hint: t("helpers.hint.adjustment.filter_expression_html"),
+    value: adjustment.filter_expression,
+    error_items: error_items(adjustment, :filter_expression)
+  } %>
+
+  <% if adjustment.boost_kind? %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: t_model_attr(:boost_factor)
+      },
+      id: "adjustment_boost_factor",
+      name: "adjustment[boost_factor]",
+      hint: t("helpers.hint.adjustment.boost_factor_html"),
+      value: adjustment.boost_factor,
+      error_items: error_items(adjustment, :boost_factor)
+    } %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("common.buttons.save", model_name: t_model_name),
+  } %>
+<% end %>

--- a/app/views/adjustments/edit.html.erb
+++ b/app/views/adjustments/edit.html.erb
@@ -1,0 +1,19 @@
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: t("adjustments.index.page_title"),
+      url: adjustments_path
+    },
+    {
+      title: @adjustment.name_was,
+      url: adjustment_path(@adjustment)
+    },
+    {
+      title: t(".page_title")
+    }
+  ]
+} %>
+
+<%= render "common/page_title", title: @adjustment.name_was %>
+
+<%= render 'form', adjustment: @adjustment %>

--- a/app/views/adjustments/index.html.erb
+++ b/app/views/adjustments/index.html.erb
@@ -1,0 +1,18 @@
+<%= render "common/page_title", title: t(".page_title") %>
+
+<div class="govuk-!-margin-top-6 app-table__container" data-module="filterable-table">
+  <%= render "govuk_publishing_components/components/table", {
+    filterable: true,
+    label: t(".filter_table_label"),
+    head: [
+      { text: t_model_attr(:name) },
+      { text: t_model_attr(:kind) },
+    ],
+    rows: @adjustments.map do |adjustment|
+      [
+        { text: link_to(adjustment.name, adjustment, class:'govuk-link') },
+        { text: t_model_enum_value(:kind, adjustment.kind) },
+      ]
+    end
+  } %>
+</div>

--- a/app/views/adjustments/index.html.erb
+++ b/app/views/adjustments/index.html.erb
@@ -1,5 +1,18 @@
 <%= render "common/page_title", title: t(".page_title") %>
 
+<div class="actions">
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("common.buttons.new", model_name: t_model_enum_value(:kind, :boost)),
+    href: new_adjustment_path(kind: :boost),
+    inline_layout: true
+  } %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("common.buttons.new", model_name: t_model_enum_value(:kind, :filter)),
+    href: new_adjustment_path(kind: :filter),
+    inline_layout: true
+  } %>
+</div>
+
 <div class="govuk-!-margin-top-6 app-table__container" data-module="filterable-table">
   <%= render "govuk_publishing_components/components/table", {
     filterable: true,

--- a/app/views/adjustments/new.html.erb
+++ b/app/views/adjustments/new.html.erb
@@ -1,0 +1,15 @@
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: t("adjustments.index.page_title"),
+      url: adjustments_path
+    },
+    {
+      title: t(".page_title", kind: t_model_enum_value(:kind, @adjustment.kind))
+    }
+  ]
+} %>
+
+<%= render "common/page_title", title: t(".page_title", kind: t_model_enum_value(:kind, @adjustment.kind)) %>
+
+<%= render "form", adjustment: @adjustment %>

--- a/app/views/adjustments/show.html.erb
+++ b/app/views/adjustments/show.html.erb
@@ -1,0 +1,34 @@
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: t("adjustments.index.page_title"),
+      url: adjustments_path
+    },
+    {
+      title: @adjustment.name
+    }
+  ]
+} %>
+
+<%= render "common/page_title", title: @adjustment.name %>
+
+<%= render "govuk_publishing_components/components/summary_list", {
+  items: [
+    {
+      field: t_model_attr(:name),
+      value: @adjustment.name,
+    },
+    {
+      field: t_model_attr(:kind),
+      value: t_model_enum_value(:kind, @adjustment.kind),
+    },
+    {
+      field: t_model_attr(:filter_expression),
+      value: @adjustment.filter_expression,
+    },
+    {
+      field: t_model_attr(:boost_factor),
+      value: @adjustment.boost_factor
+    },
+  ].reject { it[:value].blank? }
+} %>

--- a/app/views/adjustments/show.html.erb
+++ b/app/views/adjustments/show.html.erb
@@ -18,6 +18,11 @@
     href: edit_adjustment_path(@adjustment),
     inline_layout: true
   } %>
+  <%= delete_button(
+    t("common.buttons.delete", model_name: t_model_name),
+    @adjustment,
+    is_inline: true
+  ) %>
 </div>
 
 <%= render "govuk_publishing_components/components/summary_list", {

--- a/app/views/adjustments/show.html.erb
+++ b/app/views/adjustments/show.html.erb
@@ -12,6 +12,14 @@
 
 <%= render "common/page_title", title: @adjustment.name %>
 
+<div class="actions">
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("common.buttons.edit", model_name: t_model_name),
+    href: edit_adjustment_path(@adjustment),
+    inline_layout: true
+  } %>
+</div>
+
 <%= render "govuk_publishing_components/components/summary_list", {
   items: [
     {

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,10 @@ module SearchAdmin
 
     # Use YAML to serialize data into DB columns (implicit pre Rails 7.1 behaviour)
     config.active_record.default_column_serializer = YAML
+
+    # Google Discovery Engine configuration
+    config.discovery_engine_datastore = ENV.fetch("DISCOVERY_ENGINE_DATASTORE")
+    config.discovery_engine_engine = ENV.fetch("DISCOVERY_ENGINE_ENGINE")
+    config.discovery_engine_serving_config = ENV.fetch("DISCOVERY_ENGINE_SERVING_CONFIG")
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,9 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Google Discovery Engine configuration
+  config.discovery_engine_datastore = "[datastore]"
+  config.discovery_engine_engine = "[engine]"
+  config.discovery_engine_serving_config = "[serving_config]"
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,9 @@ en:
       page_title: Edit
     update:
       success: The adjustment was successfully updated.
+    destroy:
+      success: The adjustment was successfully deleted.
+      failure: The adjustment could not be deleted.
   recommended_links:
     index:
       page_title: External links

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,10 @@ en:
       page_title: New %{kind} adjustment
     create:
       success: The adjustment was successfully created.
+    edit:
+      page_title: Edit
+    update:
+      success: The adjustment was successfully updated.
   recommended_links:
     index:
       page_title: External links

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,13 @@ en:
         comment: Comments
         created_at: Created at
         updated_at: Updated at
+    errors:
+      messages:
+        discovery_engine_invalid_request: |
+          Vertex AI Search did not accept the change: %{message}.
+        discovery_engine_unrecoverable: |
+          Vertex AI Search returned an error trying to make this change. The error has been logged.
+          Please try again later.
 
   helpers:
     hint:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,10 @@ en:
         created_at: Created at
         updated_at: Updated at
 
+  adjustments:
+    index:
+      page_title: Adjustments
+      filter_table_label: Filter adjustments
   recommended_links:
     index:
       page_title: External links

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,10 +47,23 @@ en:
 
   activerecord:
     models:
+      adjustment:
+        one: adjustment
+        other: adjustments
       recommended_link:
         one: external link
         other: external links
     attributes:
+      adjustment:
+        kind: Kind
+        kind_values:
+          boost: boost
+          filter: filter
+        name: Name
+        filter_expression: Filter expression
+        boost_factor: Boost factor
+        created_at: Created at
+        updated_at: Updated at
       recommended_link:
         link: Link
         title: Title

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,10 +73,29 @@ en:
         created_at: Created at
         updated_at: Updated at
 
+  helpers:
+    hint:
+      adjustment:
+        boost_factor_html: |
+          A decimal number between -1 and 1 that determines how much to boost (positive) or bury
+          (negative) search results by, for example <code>0.13</code>.
+        filter_expression_html: |
+          A filter query that describes which documents this adjustment applies to, for example
+          <code>link: ANY("example")</code>. Note that all fields you use in the expression must be
+          "indexable" in Discovery Engine. See <a
+          href="https://cloud.google.com/generative-ai-app-builder/docs/filter-search-metadata"
+          target="_blank" class="govuk-link">Google documentation</a> for syntax and more
+          information.
+        name: A descriptive name for this adjustment, for example "Promote example content".
+
   adjustments:
     index:
       page_title: Adjustments
       filter_table_label: Filter adjustments
+    new:
+      page_title: New %{kind} adjustment
+    create:
+      success: The adjustment was successfully created.
   recommended_links:
     index:
       page_title: External links

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   )
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 
+  resources :adjustments
   resources :recommended_links, path: "/recommended-links"
 
   root "recommended_links#index"

--- a/db/migrate/20250121123111_create_adjustments.rb
+++ b/db/migrate/20250121123111_create_adjustments.rb
@@ -1,0 +1,12 @@
+class CreateAdjustments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :adjustments do |t|
+      t.integer :kind, null: false
+      t.string :name, null: false
+      t.string :filter_expression, null: false
+      t.float :boost_factor
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_10_114733) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_21_123111) do
+  create_table "adjustments", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "kind", null: false
+    t.string "name", null: false
+    t.string "filter_expression", null: false
+    t.float "boost_factor"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "recommended_links", charset: "utf8mb3", force: :cascade do |t|
     t.string "title"
     t.string "link"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,17 @@
 FactoryBot.define do
+  factory :boost_adjustment, class: Adjustment do
+    kind { :boost }
+    name { "Boost adjustment" }
+    filter_expression { 'link: ANY("/example")' }
+    boost_factor { 0.13 }
+  end
+
+  factory :filter_adjustment, class: Adjustment do
+    kind { :filter }
+    name { "Filter adjustment" }
+    filter_expression { 'link: ANY("/example")' }
+  end
+
   factory :recommended_link do
     title { "Tax online" }
     link { "https://www.tax.service.gov.uk/" }

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -74,4 +74,35 @@ RSpec.describe Adjustment, type: :model do
       end
     end
   end
+
+  describe "#control_action" do
+    subject(:control_action) { adjustment.control_action }
+
+    context "for a boost adjustment" do
+      let(:adjustment) { build_stubbed(:boost_adjustment) }
+
+      it "returns a hash with the boost action" do
+        expect(control_action).to eq(
+          boost_action: {
+            boost: adjustment.boost_factor,
+            filter: adjustment.filter_expression,
+            data_store: Rails.configuration.discovery_engine_datastore,
+          },
+        )
+      end
+    end
+
+    context "for a filter adjustment" do
+      let(:adjustment) { build_stubbed(:filter_adjustment) }
+
+      it "returns a hash with the filter action" do
+        expect(control_action).to eq(
+          filter_action: {
+            filter: adjustment.filter_expression,
+            data_store: Rails.configuration.discovery_engine_datastore,
+          },
+        )
+      end
+    end
+  end
 end

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe Adjustment, type: :model do
+  it_behaves_like "Discovery Engine syncable", DiscoveryEngine::Control do
+    let(:attributes) { attributes_for(:boost_adjustment) }
+  end
+
   describe "validations" do
     subject(:adjustment) { Adjustment.new(attributes) }
 

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe Adjustment, type: :model do
+  describe "validations" do
+    subject(:adjustment) { Adjustment.new(attributes) }
+
+    shared_examples "any adjustment" do
+      it "is valid with correct attributes" do
+        expect(adjustment).to be_valid
+      end
+
+      context "without a display name" do
+        let(:attributes) { super().merge(name: nil) }
+
+        it "fails validation" do
+          expect(adjustment).not_to be_valid
+          expect(adjustment.errors).to be_of_kind(:name, :blank)
+        end
+      end
+
+      context "without a filter expression" do
+        let(:attributes) { super().merge(filter_expression: nil) }
+
+        it "fails validation" do
+          expect(adjustment).not_to be_valid
+          expect(adjustment.errors).to be_of_kind(:filter_expression, :blank)
+        end
+      end
+    end
+
+    context "for a boost adjustment" do
+      let(:attributes) { attributes_for(:boost_adjustment) }
+
+      it_behaves_like "any adjustment"
+
+      context "without a boost factor" do
+        let(:attributes) { super().merge(boost_factor: nil) }
+
+        it "fails validation" do
+          expect(adjustment).not_to be_valid
+          expect(adjustment.errors).to be_of_kind(:boost_factor, :not_a_number)
+        end
+      end
+
+      context "with a boost factor outside the permissible range" do
+        let(:attributes) { super().merge(boost_factor: 1.1) }
+
+        it "fails validation" do
+          expect(adjustment).not_to be_valid
+          expect(adjustment.errors).to be_of_kind(:boost_factor, :in)
+        end
+      end
+
+      context "with a zero boost factor" do
+        let(:attributes) { super().merge(boost_factor: 0.0) }
+
+        it "is valid" do
+          expect(adjustment).not_to be_valid
+          expect(adjustment.errors).to be_of_kind(:boost_factor, :other_than)
+        end
+      end
+    end
+
+    context "for a filter adjustment" do
+      let(:attributes) { attributes_for(:filter_adjustment) }
+
+      it_behaves_like "any adjustment"
+
+      context "with a boost factor" do
+        let(:attributes) { super().merge(boost_factor: 0.13) }
+
+        it "fails validation" do
+          expect(adjustment).not_to be_valid
+          expect(adjustment.errors).to be_of_kind(:boost_factor, :present)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/discovery_engine/control_spec.rb
+++ b/spec/models/discovery_engine/control_spec.rb
@@ -1,0 +1,110 @@
+class FakeControllable
+  include ActiveModel::Model
+
+  attr_accessor :name
+
+  def id
+    42
+  end
+
+  def control_action
+    { fake_action: { foo: "bar" } }
+  end
+end
+
+RSpec.describe DiscoveryEngine::Control, type: :model do
+  subject { described_class.new(controllable, client:) }
+
+  let(:controllable) { FakeControllable.new(name: "A controllable") }
+  let(:client) do
+    double(
+      Google::Cloud::DiscoveryEngine::V1::ControlService::Client,
+      create_control: true,
+      update_control: true,
+      delete_control: true,
+    )
+  end
+
+  describe "#id" do
+    it "returns a unique ID based on the controllable's type and ID" do
+      expect(subject.id).to eq("search-admin-fake_controllable-42")
+    end
+  end
+
+  describe "#name" do
+    it "returns the fully qualified name of the control based on the parent engine and ID" do
+      expect(subject.name).to eq("[engine]/controls/search-admin-fake_controllable-42")
+    end
+  end
+
+  describe "#create!" do
+    it "creates the control on Discovery Engine" do
+      expect(client).to receive(:create_control).with(
+        control: {
+          name: "[engine]/controls/search-admin-fake_controllable-42",
+          display_name: "A controllable",
+          fake_action: { foo: "bar" },
+          solution_type: Google::Cloud::DiscoveryEngine::V1::SolutionType::SOLUTION_TYPE_SEARCH,
+          use_cases: [Google::Cloud::DiscoveryEngine::V1::SearchUseCase::SEARCH_USE_CASE_SEARCH],
+        },
+        control_id: "search-admin-fake_controllable-42",
+        parent: "[engine]",
+      )
+
+      subject.create!
+    end
+
+    context "when the creation fails" do
+      before do
+        allow(client).to receive(:create_control).and_raise(Google::Cloud::Error, "Uh oh")
+      end
+
+      it "raises an error" do
+        expect { subject.create! }.to raise_error(DiscoveryEngine::Error, "Uh oh")
+      end
+    end
+  end
+  describe "#update!" do
+    it "updates the control on Discovery Engine" do
+      expect(client).to receive(:update_control).with(
+        control: {
+          name: "[engine]/controls/search-admin-fake_controllable-42",
+          display_name: "A controllable",
+          fake_action: { foo: "bar" },
+          solution_type: Google::Cloud::DiscoveryEngine::V1::SolutionType::SOLUTION_TYPE_SEARCH,
+          use_cases: [Google::Cloud::DiscoveryEngine::V1::SearchUseCase::SEARCH_USE_CASE_SEARCH],
+        },
+      )
+
+      subject.update!
+    end
+
+    context "when the update fails" do
+      before do
+        allow(client).to receive(:update_control).and_raise(Google::Cloud::Error, "Uh oh")
+      end
+
+      it "raises an error" do
+        expect { subject.update! }.to raise_error(DiscoveryEngine::Error, "Uh oh")
+      end
+    end
+  end
+
+  describe "#delete!" do
+    it "deletes the control on Discovery Engine" do
+      expect(client).to receive(:delete_control).with(name: "[engine]/controls/search-admin-fake_controllable-42")
+
+      subject.delete!
+    end
+
+    context "when the deletion fails" do
+      before do
+        allow(client).to receive(:delete_control).and_raise(Google::Cloud::Error, "Uh oh")
+      end
+
+      it "raises an error" do
+        expect { subject.delete! }.to raise_error(DiscoveryEngine::Error, "Uh oh")
+      end
+    end
+  end
+end

--- a/spec/requests/adjustments_spec.rb
+++ b/spec/requests/adjustments_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "Adjustments", type: :request do
+  describe "GET new" do
+    before do
+      get new_adjustment_path, params: { kind: }
+    end
+
+    context "with a valid adjustment kind" do
+      let(:kind) { "boost" }
+
+      it "allows the user to create an adjustment" do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with an invalid adjustment kind" do
+      let(:kind) { "invalid" }
+
+      it "redirects to the adjustment path" do
+        expect(response).to redirect_to(adjustments_path)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,15 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
 
+  config.before(:all, type: :request) do
+    @user = create(:user)
+    GDS::SSO.test_user = @user
+  end
+
+  config.after(:all, type: :request) do
+    @user.destroy!
+  end
+
   config.before(:all, type: :system) do
     @user = create(:user)
     GDS::SSO.test_user = @user

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,15 @@ Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+require "grpc_mock/rspec"
+GrpcMock.disable_net_connect!
+
 require "webmock/rspec"
 WebMock.disable_net_connect!
+
+# Required to be able to stub Google classes in tests (as classes from the `v1` namespace are not
+# used directly in non-test code, they are not loaded by the gem's lazy loading)
+require "google/cloud/discovery_engine/v1"
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!

--- a/spec/support/shared_examples/discovery_engine_syncable.rb
+++ b/spec/support/shared_examples/discovery_engine_syncable.rb
@@ -1,0 +1,115 @@
+RSpec.shared_examples "Discovery Engine syncable" do |resource_class|
+  let(:resource) do
+    instance_double(resource_class, create!: true, update!: true, delete!: true)
+  end
+
+  before do
+    allow(resource_class).to receive(:new).with(record).and_return(resource)
+  end
+
+  describe "#save_and_sync for a new record" do
+    subject(:record) { described_class.new(attributes) }
+
+    it "creates the resource" do
+      record.save_and_sync
+
+      expect(resource).to have_received(:create!)
+    end
+
+    it "persists the record" do
+      record.save_and_sync
+
+      expect(record).to be_persisted
+    end
+
+    context "when the resource creation fails" do
+      let(:error) { DiscoveryEngine::Error.new("Uh oh") }
+
+      before do
+        allow(resource).to receive(:create!).and_raise(error)
+      end
+
+      it "does not persist the record" do
+        record.save_and_sync
+
+        expect(record).not_to be_persisted
+      end
+
+      it "adds an error to the record" do
+        record.save_and_sync
+
+        expect(record.errors).to be_of_kind(:base, :discovery_engine_unrecoverable)
+      end
+    end
+  end
+
+  describe "#save_and_sync for an existing record" do
+    subject(:record) { described_class.create!(attributes) }
+
+    before do
+      record.name = "New name"
+    end
+
+    it "updates the resource" do
+      expect(resource).to receive(:update!)
+
+      record.save_and_sync
+    end
+
+    context "when the resource update fails" do
+      let(:error) { DiscoveryEngine::Error.new("Uh oh") }
+
+      before do
+        allow(resource).to receive(:update!).and_raise(error)
+      end
+
+      it "does not persist the changes to the record" do
+        record.save_and_sync
+
+        expect(record).to be_changed
+      end
+
+      it "adds an error to the record" do
+        record.save_and_sync
+
+        expect(record.errors).to be_of_kind(:base, :discovery_engine_unrecoverable)
+      end
+    end
+  end
+
+  describe "#destroy_and_sync" do
+    subject(:record) { described_class.create!(attributes) }
+
+    it "deletes the resource" do
+      record.destroy_and_sync
+
+      expect(resource).to have_received(:delete!)
+    end
+
+    it "destroys the record" do
+      record.destroy_and_sync
+
+      expect(record).to be_destroyed
+    end
+
+    context "when the resource deletion fails" do
+      let(:error) { DiscoveryEngine::Error.new("Uh oh") }
+
+      before do
+        allow(resource).to receive(:delete!).and_raise(error)
+      end
+
+      it "does not destroy the record" do
+        record.destroy_and_sync
+
+        expect(record).to be_persisted
+      end
+
+      it "adds an error to the record" do
+        record.destroy_and_sync
+
+        expect(record.errors).to be_of_kind(:base, :discovery_engine_unrecoverable)
+      end
+    end
+  end
+end

--- a/spec/system/adjustments_spec.rb
+++ b/spec/system/adjustments_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe "Adjustments", type: :system do
+  scenario "Viewing adjustments" do
+    given_several_adjustments_exist
+    when_i_visit_the_adjustments_page
+    then_i_should_see_all_the_adjustments
+    and_i_can_click_through_to_see_more_details
+  end
+
+  def given_several_adjustments_exist
+    given_a_boost_adjustment_exists
+    given_a_filter_adjustment_exists
+  end
+
+  def given_a_boost_adjustment_exists
+    @boost_adjustment = create(:boost_adjustment)
+  end
+
+  def given_a_filter_adjustment_exists
+    @filter_adjustment = create(:filter_adjustment)
+  end
+
+  def when_i_visit_the_adjustments_page
+    visit adjustments_path
+  end
+
+  def then_i_should_see_all_the_adjustments
+    expect(page).to have_link(@boost_adjustment.name)
+    expect(page).to have_link(@filter_adjustment.name)
+  end
+
+  def and_i_can_click_through_to_see_more_details
+    click_link @boost_adjustment.name
+
+    expect(page).to have_selector("h1", text: @boost_adjustment.name)
+    expect(page).to have_content(@boost_adjustment.filter_expression)
+  end
+end

--- a/spec/system/adjustments_spec.rb
+++ b/spec/system/adjustments_spec.rb
@@ -22,6 +22,26 @@ RSpec.describe "Adjustments", type: :system do
     and_i_can_see_the_filter_adjustment_details
   end
 
+  scenario "Editing a boost adjustment" do
+    given_a_boost_adjustment_exists
+    when_i_view_the_boost_adjustment
+    and_i_click_the_edit_button
+    and_i_update_the_adjustment
+
+    then_the_boost_adjustment_should_be_updated
+    and_i_can_see_the_updated_details
+  end
+
+  scenario "Editing a filter adjustment" do
+    given_a_filter_adjustment_exists
+    when_i_view_the_filter_adjustment
+    and_i_click_the_edit_button
+    and_i_update_the_adjustment
+
+    then_the_filter_adjustment_should_be_updated
+    and_i_can_see_the_updated_details
+  end
+
   def given_several_adjustments_exist
     given_a_boost_adjustment_exists
     given_a_filter_adjustment_exists
@@ -62,6 +82,24 @@ RSpec.describe "Adjustments", type: :system do
     click_button "Save adjustment"
   end
 
+  def when_i_view_the_boost_adjustment
+    visit adjustment_path(@boost_adjustment)
+  end
+
+  def when_i_view_the_filter_adjustment
+    visit adjustment_path(@filter_adjustment)
+  end
+
+  def and_i_click_the_edit_button
+    click_link "Edit"
+  end
+
+  def and_i_update_the_adjustment
+    fill_in "Name", with: "Updated adjustment"
+
+    click_button "Save adjustment"
+  end
+
   def then_i_should_see_all_the_adjustments
     expect(page).to have_link(@boost_adjustment.name)
     expect(page).to have_link(@filter_adjustment.name)
@@ -93,5 +131,19 @@ RSpec.describe "Adjustments", type: :system do
   def and_i_can_see_the_filter_adjustment_details
     expect(page).to have_selector("h1", text: "Filter adjustment")
     expect(page).to have_content('Filter expression link: ANY("/example")')
+  end
+
+  def then_the_boost_adjustment_should_be_updated
+    expect(page).to have_content("The adjustment was successfully updated.")
+    expect(@boost_adjustment.reload.name).to eq("Updated adjustment")
+  end
+
+  def then_the_filter_adjustment_should_be_updated
+    expect(page).to have_content("The adjustment was successfully updated.")
+    expect(@filter_adjustment.reload.name).to eq("Updated adjustment")
+  end
+
+  def and_i_can_see_the_updated_details
+    expect(page).to have_selector("h1", text: "Updated adjustment")
   end
 end

--- a/spec/system/adjustments_spec.rb
+++ b/spec/system/adjustments_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe "Adjustments", type: :system do
     and_i_can_see_the_updated_details
   end
 
+  scenario "Deleting an adjustment" do
+    given_a_boost_adjustment_exists
+    when_i_view_the_boost_adjustment
+    and_i_click_the_delete_button
+
+    then_the_boost_adjustment_should_be_deleted
+  end
+
   def given_several_adjustments_exist
     given_a_boost_adjustment_exists
     given_a_filter_adjustment_exists
@@ -100,6 +108,10 @@ RSpec.describe "Adjustments", type: :system do
     click_button "Save adjustment"
   end
 
+  def and_i_click_the_delete_button
+    click_button "Delete"
+  end
+
   def then_i_should_see_all_the_adjustments
     expect(page).to have_link(@boost_adjustment.name)
     expect(page).to have_link(@filter_adjustment.name)
@@ -145,5 +157,10 @@ RSpec.describe "Adjustments", type: :system do
 
   def and_i_can_see_the_updated_details
     expect(page).to have_selector("h1", text: "Updated adjustment")
+  end
+
+  def then_the_boost_adjustment_should_be_deleted
+    expect(page).to have_content("The adjustment was successfully deleted.")
+    expect(Adjustment.count).to be_zero
   end
 end

--- a/spec/system/adjustments_spec.rb
+++ b/spec/system/adjustments_spec.rb
@@ -1,4 +1,12 @@
 RSpec.describe "Adjustments", type: :system do
+  let(:control) do
+    instance_double(DiscoveryEngine::Control, create!: true, update!: true, delete!: true)
+  end
+
+  before do
+    allow(DiscoveryEngine::Control).to receive(:new).and_return(control)
+  end
+
   scenario "Viewing adjustments" do
     given_several_adjustments_exist
     when_i_visit_the_adjustments_page
@@ -127,11 +135,13 @@ RSpec.describe "Adjustments", type: :system do
   def then_the_boost_adjustment_should_be_created
     expect(page).to have_content("The adjustment was successfully created.")
     expect(Adjustment.first).to be_boost_kind
+    expect(control).to have_received(:create!)
   end
 
   def then_the_filter_adjustment_should_be_created
     expect(page).to have_content("The adjustment was successfully created.")
     expect(Adjustment.first).to be_filter_kind
+    expect(control).to have_received(:create!)
   end
 
   def and_i_can_see_the_boost_adjustment_details
@@ -148,11 +158,13 @@ RSpec.describe "Adjustments", type: :system do
   def then_the_boost_adjustment_should_be_updated
     expect(page).to have_content("The adjustment was successfully updated.")
     expect(@boost_adjustment.reload.name).to eq("Updated adjustment")
+    expect(control).to have_received(:update!)
   end
 
   def then_the_filter_adjustment_should_be_updated
     expect(page).to have_content("The adjustment was successfully updated.")
     expect(@filter_adjustment.reload.name).to eq("Updated adjustment")
+    expect(control).to have_received(:update!)
   end
 
   def and_i_can_see_the_updated_details
@@ -162,5 +174,6 @@ RSpec.describe "Adjustments", type: :system do
   def then_the_boost_adjustment_should_be_deleted
     expect(page).to have_content("The adjustment was successfully deleted.")
     expect(Adjustment.count).to be_zero
+    expect(control).to have_received(:delete!)
   end
 end

--- a/spec/system/adjustments_spec.rb
+++ b/spec/system/adjustments_spec.rb
@@ -6,6 +6,22 @@ RSpec.describe "Adjustments", type: :system do
     and_i_can_click_through_to_see_more_details
   end
 
+  scenario "Creating a new boost" do
+    when_i_visit_the_adjustments_page
+    and_i_click_the_new_boost_button
+    and_i_fill_in_the_form_with_boost_adjustment_details
+    then_the_boost_adjustment_should_be_created
+    and_i_can_see_the_boost_adjustment_details
+  end
+
+  scenario "Creating a new filter" do
+    when_i_visit_the_adjustments_page
+    and_i_click_the_new_filter_button
+    and_i_fill_in_the_form_with_filter_adjustment_details
+    then_the_filter_adjustment_should_be_created
+    and_i_can_see_the_filter_adjustment_details
+  end
+
   def given_several_adjustments_exist
     given_a_boost_adjustment_exists
     given_a_filter_adjustment_exists
@@ -23,6 +39,29 @@ RSpec.describe "Adjustments", type: :system do
     visit adjustments_path
   end
 
+  def and_i_click_the_new_boost_button
+    click_link "New boost"
+  end
+
+  def and_i_click_the_new_filter_button
+    click_link "New filter"
+  end
+
+  def and_i_fill_in_the_form_with_boost_adjustment_details
+    fill_in "Name", with: "Boost adjustment"
+    fill_in "Filter expression", with: 'link: ANY("/example")'
+    fill_in "Boost factor", with: 0.42
+
+    click_button "Save adjustment"
+  end
+
+  def and_i_fill_in_the_form_with_filter_adjustment_details
+    fill_in "Name", with: "Filter adjustment"
+    fill_in "Filter expression", with: 'link: ANY("/example")'
+
+    click_button "Save adjustment"
+  end
+
   def then_i_should_see_all_the_adjustments
     expect(page).to have_link(@boost_adjustment.name)
     expect(page).to have_link(@filter_adjustment.name)
@@ -33,5 +72,26 @@ RSpec.describe "Adjustments", type: :system do
 
     expect(page).to have_selector("h1", text: @boost_adjustment.name)
     expect(page).to have_content(@boost_adjustment.filter_expression)
+  end
+
+  def then_the_boost_adjustment_should_be_created
+    expect(page).to have_content("The adjustment was successfully created.")
+    expect(Adjustment.first).to be_boost_kind
+  end
+
+  def then_the_filter_adjustment_should_be_created
+    expect(page).to have_content("The adjustment was successfully created.")
+    expect(Adjustment.first).to be_filter_kind
+  end
+
+  def and_i_can_see_the_boost_adjustment_details
+    expect(page).to have_selector("h1", text: "Boost adjustment")
+    expect(page).to have_content('Filter expression link: ANY("/example")')
+    expect(page).to have_content("Boost factor 0.42")
+  end
+
+  def and_i_can_see_the_filter_adjustment_details
+    expect(page).to have_selector("h1", text: "Filter adjustment")
+    expect(page).to have_content('Filter expression link: ANY("/example")')
   end
 end


### PR DESCRIPTION
This adds the ability to manage **adjustments** to Search Admin.

An adjustment is a specific modification of the search results returned on GOV.UK. It consists of a descriptive name, and a filter expression that describes what content items (documents) it applies to based on their metadata.

An adjustment can either change the ranking of matching content in results by a specific factor ("boost") or remove matching documents from results entirely ("filter"). Both of these kinds of adjustment are represented as [serving controls] ("controls") on the Discovery Engine API for Vertex AI Search. There are also additional types of serving controls available that we will use in upcoming features, so the ability to manage the remote control resources is kept generic from the start.

This adds a basic CRUD UI for adjustments to the application, as well as transactional synchronisation of adjustments to Discovery Engine.

This is the first iteration of this feature, and the following are not part of this PR to avoid it getting too big:
* a more user-friendly UI
* activating controls on Discovery Engine by attaching them to a serving configuration (needs some infrastructure work to create a new serving configuration)
* auditing and commenting functionality for admin users (this makes sense to do as shared functionality between this and other models in the future)

## Screenshots
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/5bab8fed-630d-4044-b072-e0b004fc145b" />
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/0351025b-7eaa-4040-8467-aa10e9dd6cb0" />
<img width="998" alt="image" src="https://github.com/user-attachments/assets/96b0a764-8d3e-4870-99dc-7b44e2c965a1" />

[serving controls]: https://cloud.google.com/generative-ai-app-builder/docs/configure-serving-controls