### PR TITLE
Improve app authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,5 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  include GDS::SSO::ControllerMethods
-  before_action :authenticate_user!
+  include Authentication
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,8 +5,4 @@ class ApplicationController < ActionController::Base
 
   include GDS::SSO::ControllerMethods
   before_action :authenticate_user!
-
-  def admin_user?
-    current_user.permissions.include?("admin")
-  end
 end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,0 +1,10 @@
+# Requires a user to be logged in through GDS SSO for any action.
+module Authentication
+  extend ActiveSupport::Concern
+
+  included do
+    include GDS::SSO::ControllerMethods
+
+    before_action :authenticate_user!
+  end
+end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,10 +1,17 @@
-# Requires a user to be logged in through GDS SSO for any action.
+# Requires a user to be logged in through GDS SSO for any action, and keeps track of the current
+# user through `Current`.
 module Authentication
   extend ActiveSupport::Concern
 
   included do
     include GDS::SSO::ControllerMethods
 
-    before_action :authenticate_user!
+    before_action :authenticate_user!, :set_current
+  end
+
+private
+
+  def set_current
+    Current.user = current_user
   end
 end

--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -59,6 +59,6 @@ private
   def recommended_link_params
     params
       .expect(recommended_link: %i[link title description keywords comment])
-      .merge(user_id: current_user.id)
+      .merge(user_id: Current.user.id)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def navigation_items
-    return [] unless current_user
+    return [] unless Current.user
 
     [
       {
@@ -9,7 +9,7 @@ module ApplicationHelper
         active: controller.controller_name == "recommended_links",
       },
       {
-        text: current_user.name,
+        text: Current.user.name,
         href: Plek.new.external_url_for("signon"),
       },
       {

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,11 @@
 class User < ApplicationRecord
+  ADMIN_PERMISSION_KEY = "admin".freeze
+
   include GDS::SSO::User
 
   serialize :permissions, type: Array
+
+  def admin?
+    permissions.include?(ADMIN_PERMISSION_KEY)
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,21 @@
+require "gds-sso/lint/user_spec"
+
+RSpec.describe User, type: :model do
+  it_behaves_like "a gds-sso user class"
+
+  describe "#admin?" do
+    subject(:user) { build_stubbed(:user, permissions:) }
+
+    context "when the user has the `admin` permission" do
+      let(:permissions) { %w[admin and others] }
+
+      it { is_expected.to be_admin }
+    end
+
+    context "when the user does not have the `admin` permission" do
+      let(:permissions) { %w[blah] }
+
+      it { is_expected.not_to be_admin }
+    end
+  end
+end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,0 +1,38 @@
+class FakeController < ApplicationController
+  def hello
+    render plain: "Hello, world!"
+  end
+end
+
+RSpec.describe "Authentication", type: :request do
+  before(:all) do
+    Rails.application.routes.draw do
+      get "hello" => "fake#hello"
+    end
+  end
+
+  after(:all) do
+    Rails.application.reload_routes!
+  end
+
+  context "when the user is authenticated" do
+    include_context "with an SSO authenticated user"
+
+    it "allows the request to proceed" do
+      get hello_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq("Hello, world!")
+    end
+  end
+
+  context "when the user is unauthenticated" do
+    include_context "without an SSO authenticated user"
+
+    it "redirects to the GDS SSO page" do
+      get hello_path
+
+      expect(response).to redirect_to("http://www.example.com/auth/gds")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,14 +31,8 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
 
-  config.before(:all, type: :system) do
-    @user = create(:user)
-    GDS::SSO.test_user = @user
-  end
-
-  config.after(:all, type: :system) do
-    @user.destroy!
-  end
+  config.include SharedContexts::Authentication
+  config.include_context "with an SSO authenticated user", type: :system
 
   config.before(:each, type: :system) do
     driven_by :rack_test

--- a/spec/support/shared_contexts/authentication.rb
+++ b/spec/support/shared_contexts/authentication.rb
@@ -1,0 +1,25 @@
+module SharedContexts
+  module Authentication
+    RSpec.shared_context "with an SSO authenticated user" do
+      let(:sso_user) { create(:user) }
+
+      before do
+        GDS::SSO.test_user = sso_user
+      end
+
+      after do
+        GDS::SSO.test_user = nil
+      end
+    end
+
+    RSpec.shared_context "without an SSO authenticated user" do
+      before do
+        # Unfortunately gds-sso assumes that a nil `test_user` is undesirable, and loads the first
+        # user from the database. Pretending to set this environment variable is the only way to
+        # force an unauthenticated state.
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("GDS_SSO_MOCK_INVALID").and_return("1")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This improves various aspects of the authentication logic in this app, including:
- Adding model tests for the `User` model
- Adding request tests for authentication overall
- Cleaning up how system and request tests deal with setting the GDS SSO test user, and fixing a bug where the test user wasn't reset properly in the `after(:all)` block
- Moving authentication into a concern for a tidier `ApplicationController`
- Creating and using a `Current` model with [ActiveSupport::CurrentAttributes] to help with future auditing features (we have prior art for this pattern in [Whitehall])

[ActiveSupport::CurrentAttributes]: https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html
[Whitehall]: https://github.com/alphagov/whitehall/blob/main/app/models/current.rb