### PR TITLE
Add control management for filters and boosts

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -13,6 +13,10 @@ on:
         default: main
         type: string
 
+env:
+  DISCOVERY_ENGINE_DATASTORE: not-used
+  DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME: not-used
+
 jobs:
   run-rspec:
     name: Run RSpec

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "sprockets-rails"
 # GDS managed gems
 gem "gds-api-adapters"
 gem "gds-sso"
+gem "google-cloud-discovery_engine"
 gem "govuk_app_config"
 gem "govuk_publishing_components"
 gem "mail-notify"
@@ -24,6 +25,7 @@ group :test do
   gem "factory_bot_rails"
   gem "govuk_schemas"
   gem "govuk_test"
+  gem "grpc_mock"
   gem "simplecov"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,8 +123,20 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
+    faraday-retry (2.2.1)
+      faraday (~> 2.0)
     ffi (1.17.1)
     foreman (0.88.1)
+    gapic-common (0.25.0)
+      faraday (>= 1.9, < 3.a)
+      faraday-retry (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.2)
+      google-logging-utils (~> 0.1)
+      google-protobuf (>= 3.25, < 5.a)
+      googleapis-common-protos (~> 1.6)
+      googleapis-common-protos-types (~> 1.15)
+      googleauth (~> 1.12)
+      grpc (~> 1.66)
     gds-api-adapters (98.2.0)
       addressable
       link_header
@@ -142,11 +154,45 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-cloud-core (1.7.1)
+      google-cloud-env (>= 1.0, < 3.a)
+      google-cloud-errors (~> 1.0)
+    google-cloud-discovery_engine (1.1.0)
+      google-cloud-core (~> 1.6)
+      google-cloud-discovery_engine-v1 (~> 1.1)
+      google-cloud-discovery_engine-v1beta (>= 0.15, < 2.a)
+    google-cloud-discovery_engine-v1 (1.4.0)
+      gapic-common (>= 0.24.0, < 2.a)
+      google-cloud-errors (~> 1.0)
+      google-cloud-location (>= 0.7, < 2.a)
+    google-cloud-discovery_engine-v1beta (0.17.0)
+      gapic-common (>= 0.24.0, < 2.a)
+      google-cloud-errors (~> 1.0)
+      google-cloud-location (>= 0.7, < 2.a)
+    google-cloud-env (2.2.1)
+      faraday (>= 1.0, < 3.a)
+    google-cloud-errors (1.4.0)
+    google-cloud-location (0.9.0)
+      gapic-common (>= 0.24.0, < 2.a)
+      google-cloud-errors (~> 1.0)
+    google-logging-utils (0.1.0)
     google-protobuf (4.29.3)
       bigdecimal
       rake (>= 13)
+    googleapis-common-protos (1.6.0)
+      google-protobuf (>= 3.18, < 5.a)
+      googleapis-common-protos-types (~> 1.7)
+      grpc (~> 1.41)
     googleapis-common-protos-types (1.18.0)
       google-protobuf (>= 3.18, < 5.a)
+    googleauth (1.13.1)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.2)
+      google-logging-utils (~> 0.1)
+      jwt (>= 1.4, < 3.0)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (>= 0.16, < 2.a)
     govuk_app_config (9.16.1)
       logstasher (~> 2.1)
       opentelemetry-exporter-otlp (>= 0.25, < 0.30)
@@ -180,6 +226,11 @@ GEM
       capybara (>= 3.36)
       puma
       selenium-webdriver (>= 4.0)
+    grpc (1.69.0)
+      google-protobuf (>= 3.25, < 5.0)
+      googleapis-common-protos-types (~> 1.0)
+    grpc_mock (0.4.6)
+      grpc (>= 1.12.0, < 2)
     hashdiff (1.1.2)
     hashie (5.0.0)
     http-accept (1.7.0)
@@ -234,6 +285,7 @@ GEM
     mini_portile2 (2.8.8)
     minitest (5.25.4)
     msgpack (1.7.5)
+    multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mysql2 (0.5.6)
@@ -472,6 +524,7 @@ GEM
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.10.1)
       opentelemetry-api (~> 1.0)
+    os (1.1.4)
     ostruct (0.6.1)
     parallel (1.26.3)
     parser (3.3.7.0)
@@ -623,6 +676,11 @@ GEM
     sentry-ruby (5.22.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    signet (0.19.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -680,10 +738,12 @@ DEPENDENCIES
   foreman
   gds-api-adapters
   gds-sso
+  google-cloud-discovery_engine
   govuk_app_config
   govuk_publishing_components
   govuk_schemas
   govuk_test
+  grpc_mock
   listen
   mail-notify
   mysql2

--- a/app/clients/client_error.rb
+++ b/app/clients/client_error.rb
@@ -1,0 +1,2 @@
+# A generic error that occurred during a client operation
+class ClientError < StandardError; end

--- a/app/clients/discovery_engine/control_client.rb
+++ b/app/clients/discovery_engine/control_client.rb
@@ -1,0 +1,58 @@
+module DiscoveryEngine
+  # Client to synchronise `Control`s to Discovery Engine
+  class ControlClient
+    # Creates a corresponding resource for this control on Discovery Engine.
+    def create(control)
+      discovery_engine_client.create_control(
+        control: control.to_discovery_engine_control,
+        control_id: control.discovery_engine_id,
+        parent: control.parent,
+      )
+    rescue Google::Cloud::Error => e
+      set_record_errors(control, e)
+      raise ClientError, "Could not create control: #{e.message}"
+    end
+
+    # Updates the corresponding resource for this control on Discovery Engine.
+    def update(control)
+      discovery_engine_client.update_control(control: control.to_discovery_engine_control)
+    rescue Google::Cloud::Error => e
+      set_record_errors(control, e)
+      raise ClientError, "Could not update control: #{e.message}"
+    end
+
+    # Deletes the corresponding resource for this control on Discovery Engine.
+    def delete(control)
+      discovery_engine_client.delete_control(name: control.name)
+    rescue Google::Cloud::Error => e
+      set_record_errors(control, e)
+      raise ClientError, "Could not delete control: #{e.message}"
+    end
+
+  private
+
+    attr_reader :control
+
+    def set_record_errors(control, error)
+      # There is no way to extract structured error information from the Google API client, so we
+      # have to resort to regex matching to see if we can extract the cause of the error.
+      #
+      # In this case, we know that if the error message contains "filter syntax", the user probably
+      # made a mistake entering the filter expression and we can attach the error to that field.
+      # Otherwise, we consider it an unknown error and make sure to log it.
+      case error.message
+      when /filter syntax/i
+        control.action.errors.add(:filter_expression, error.details)
+      else
+        control.errors.add(:base, :remote_error)
+
+        GovukError.notify(error)
+        Rails.logger.error(error.message)
+      end
+    end
+
+    def discovery_engine_client
+      Google::Cloud::DiscoveryEngine.control_service(version: :v1)
+    end
+  end
+end

--- a/app/controllers/controls_controller.rb
+++ b/app/controllers/controls_controller.rb
@@ -5,11 +5,35 @@ class ControlsController < ApplicationController
     @controls = Control.includes(:action).order(:display_name)
   end
 
+  def new
+    @control = Control.new(action: params[:action_type].new)
+  end
+
+  def create
+    @control = Control.new(control_params)
+
+    if @control.save
+      redirect_to @control, notice: t(".success")
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
   def show; end
 
 private
 
   def set_control
     @control = Control.includes(:action).find(params[:id])
+  end
+
+  def control_params
+    params.expect(
+      control: [
+        :display_name,
+        :action_type,
+        { action_attributes: %i[boost_factor filter_expression] },
+      ],
+    )
   end
 end

--- a/app/controllers/controls_controller.rb
+++ b/app/controllers/controls_controller.rb
@@ -1,5 +1,5 @@
 class ControlsController < ApplicationController
-  before_action :set_control, only: %i[show edit update]
+  before_action :set_control, only: %i[show edit update destroy]
 
   def index
     @controls = Control.includes(:action).order(:display_name)
@@ -30,6 +30,14 @@ class ControlsController < ApplicationController
       redirect_to @control, notice: t(".success")
     else
       render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @control.destroy
+      redirect_to controls_path, notice: t(".success")
+    else
+      redirect_to @control, alert: t(".failure")
     end
   end
 

--- a/app/controllers/controls_controller.rb
+++ b/app/controllers/controls_controller.rb
@@ -1,0 +1,15 @@
+class ControlsController < ApplicationController
+  before_action :set_control, only: %i[show]
+
+  def index
+    @controls = Control.includes(:action).order(:display_name)
+  end
+
+  def show; end
+
+private
+
+  def set_control
+    @control = Control.includes(:action).find(params[:id])
+  end
+end

--- a/app/controllers/controls_controller.rb
+++ b/app/controllers/controls_controller.rb
@@ -1,5 +1,5 @@
 class ControlsController < ApplicationController
-  before_action :set_control, only: %i[show]
+  before_action :set_control, only: %i[show edit update]
 
   def index
     @controls = Control.includes(:action).order(:display_name)
@@ -20,6 +20,18 @@ class ControlsController < ApplicationController
   end
 
   def show; end
+
+  def edit; end
+
+  def update
+    @control.assign_attributes(control_params.except(:action_type))
+
+    if @control.save
+      redirect_to @control, notice: t(".success")
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
 private
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,11 @@ module ApplicationHelper
         active: controller.controller_name == "recommended_links",
       },
       {
+        text: t("controls.index.page_title"),
+        href: controls_path,
+        active: controller.controller_name == "controls",
+      },
+      {
         text: current_user.name,
         href: Plek.new.external_url_for("signon"),
       },

--- a/app/helpers/model_translation_helper.rb
+++ b/app/helpers/model_translation_helper.rb
@@ -1,14 +1,18 @@
 # Provides more concise helper methods for translating model names and attributes, assuming that the
 # current controller is named after the model it is managing.
 module ModelTranslationHelper
-  # Returns the translated model name for the current controller.
-  def t_model_name(count: 1)
-    inferred_model_class.model_name.human(count:)
+  # Returns the translated model name for a given model or record, or if not provided, the model
+  # corresponding to the current controller.
+  def t_model_name(model_or_record = nil, count: 1)
+    target = model_or_record || inferred_model_class
+    target.model_name.human(count:)
   end
 
-  # Returns the translated name for the given attribute on the current controller's model.
-  def t_model_attr(attr)
-    inferred_model_class.human_attribute_name(attr)
+  # Returns the translated name for the given attribute on a given model or record, or if not
+  # provided, the current controller's model.
+  def t_model_attr(attr, on: nil)
+    target = on&.class || inferred_model_class
+    target.human_attribute_name(attr)
   end
 
 private

--- a/app/models/concerns/remote_synchronizable.rb
+++ b/app/models/concerns/remote_synchronizable.rb
@@ -1,0 +1,68 @@
+# Enhances a model with lifecycle callbacks to synchronise it with a remote resource using a client
+# class (conventionally located in `app/clients/`).
+#
+# Example:
+# ```ruby
+# class Foo < ApplicationRecord
+#   include RemoteSynchronizable
+#   remote_synchronize with: BarApi::FooClient
+# end
+# ```
+#
+# If the remote operation fails, the record will not be created/updated/destroyed, and will be
+# marked invalid.
+module RemoteSynchronizable
+  extend ActiveSupport::Concern
+
+  included do
+    # Client class to use for synchronisation
+    class_attribute :client_class
+
+    # Create and update the remote resource using the client during ActiveRecord lifecycle events.
+    #
+    # Normally we would avoid using ActiveRecord callbacks to make network calls, but as the core
+    # purpose of Search Admin is to provide an interface to manage resources on various remote APIs,
+    # this is part of its core domain.
+    before_create :create_remote, unless: :skip_remote_synchronization_on_create
+    before_update :update_remote
+    before_destroy :destroy_remote
+
+    # Skips the creation of the remote synchronisation on create.
+    #
+    # This allows to create new instances of a record without a remote counterpart, for example
+    # when importing existing remote resources, or as part of test setup (see `spec/factories.rb`).
+    attr_accessor :skip_remote_synchronization_on_create
+  end
+
+  class_methods do
+    # Set the class to be used for synchronisation for this model. It must allow initialisation with
+    # a record, and respond to `#create`, `#update` and `#delete`.
+    def remote_synchronize(with:)
+      self.client_class = with
+    end
+  end
+
+private
+
+  def create_remote
+    client.create(self) # rubocop:disable Rails/SaveBang (not an ActiveRecord model)
+  rescue ClientError
+    raise ActiveRecord::RecordInvalid, self
+  end
+
+  def update_remote
+    client.update(self) # rubocop:disable Rails/SaveBang (not an ActiveRecord model)
+  rescue ClientError
+    raise ActiveRecord::RecordInvalid, self
+  end
+
+  def destroy_remote
+    client.delete(self)
+  rescue ClientError
+    throw :abort
+  end
+
+  def client
+    @client ||= client_class.new
+  end
+end

--- a/app/models/control.rb
+++ b/app/models/control.rb
@@ -10,6 +10,9 @@
 # see
 # https://cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1/latest/Google-Cloud-DiscoveryEngine-V1-Control
 class Control < ApplicationRecord
+  include RemoteSynchronizable
+  remote_synchronize with: DiscoveryEngine::ControlClient
+
   delegated_type :action, types: %w[Control::BoostAction Control::FilterAction], dependent: :destroy
   accepts_nested_attributes_for :action, update_only: true
 

--- a/app/models/control.rb
+++ b/app/models/control.rb
@@ -14,4 +14,31 @@ class Control < ApplicationRecord
   accepts_nested_attributes_for :action, update_only: true
 
   validates :display_name, presence: true
+
+  # Returns a representation of this Control as a Discovery Engine control resource
+  def to_discovery_engine_control
+    {
+      name:,
+      display_name:,
+      **action.to_discovery_engine_control_action,
+      solution_type: Google::Cloud::DiscoveryEngine::V1::SolutionType::SOLUTION_TYPE_SEARCH,
+      # Trip hazard: despite the plural name, this expects _one_ use case in an array
+      use_cases: [Google::Cloud::DiscoveryEngine::V1::SearchUseCase::SEARCH_USE_CASE_SEARCH],
+    }
+  end
+
+  # The fully qualified name of the control on Discovery Engine (like a path)
+  def name
+    [parent, "controls", discovery_engine_id].join("/")
+  end
+
+  # The parent of the control on Discovery Engine (always the engine)
+  def parent
+    Rails.configuration.discovery_engine_engine
+  end
+
+  # The ID of the resource on Discovery Engine
+  def discovery_engine_id
+    "search-admin-#{id}"
+  end
 end

--- a/app/models/control.rb
+++ b/app/models/control.rb
@@ -1,0 +1,17 @@
+# Represents a Control resource on Discovery Engine.
+#
+# Each control is a single, specific customisation of search engine behaviour that can affect how
+# a query is processed, or how results are returned.
+#
+# There are several different kinds of actions a control can have, such as filtering or boosting
+# certain results, which we model as an `action` delegated type (see `types` argument to
+# `delegated_type :action`).
+#
+# see
+# https://cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1/latest/Google-Cloud-DiscoveryEngine-V1-Control
+class Control < ApplicationRecord
+  delegated_type :action, types: %w[Control::BoostAction Control::FilterAction], dependent: :destroy
+  accepts_nested_attributes_for :action, update_only: true
+
+  validates :display_name, presence: true
+end

--- a/app/models/control/actionable.rb
+++ b/app/models/control/actionable.rb
@@ -1,0 +1,9 @@
+# Provides functionality for models acting as the `action` delegated type of `Control`, in
+# particular their relationship back to the control.
+module Control::Actionable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :control, as: :action, touch: true, dependent: :destroy
+  end
+end

--- a/app/models/control/actionable.rb
+++ b/app/models/control/actionable.rb
@@ -6,4 +6,10 @@ module Control::Actionable
   included do
     has_one :control, as: :action, touch: true, dependent: :destroy
   end
+
+  # Allow rendering an action partial as just its unqualified name when using `render`, e.g.
+  # `filter_action` instead of `control/filter_actions/filter_action`.
+  def to_partial_path
+    model_name.element
+  end
 end

--- a/app/models/control/boost_action.rb
+++ b/app/models/control/boost_action.rb
@@ -1,0 +1,19 @@
+# Represents a boost action for a `Control`.
+#
+# Allows changing the ranking of search results for documents matching a given filter expression, by
+# applying a positive (promotion) or negative (demotion) boost factor to them.
+#
+# For example, we could:
+# - promote important content types
+# - make content that is less relevant to users to appear lower in search results
+#
+# see https://cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1/latest/Google-Cloud-DiscoveryEngine-V1-Control-BoostAction
+class Control::BoostAction < ApplicationRecord
+  include Control::Actionable
+
+  # The range of permissible boost values, from maximum demotion to maximum promotion.
+  BOOST_FACTOR_RANGE = -1.0..1.0
+
+  validates :filter_expression, presence: true
+  validates :boost_factor, numericality: { in: BOOST_FACTOR_RANGE, other_than: 0 }
+end

--- a/app/models/control/boost_action.rb
+++ b/app/models/control/boost_action.rb
@@ -16,4 +16,15 @@ class Control::BoostAction < ApplicationRecord
 
   validates :filter_expression, presence: true
   validates :boost_factor, numericality: { in: BOOST_FACTOR_RANGE, other_than: 0 }
+
+  # Returns a representation of this boost as part of a Discovery Engine control resource
+  def to_discovery_engine_control_action
+    {
+      boost_action: {
+        filter: filter_expression,
+        boost: boost_factor,
+        data_store: Rails.configuration.discovery_engine_datastore,
+      },
+    }
+  end
 end

--- a/app/models/control/filter_action.rb
+++ b/app/models/control/filter_action.rb
@@ -10,4 +10,14 @@ class Control::FilterAction < ApplicationRecord
   include Control::Actionable
 
   validates :filter_expression, presence: true
+
+  # Returns a representation of this filter as part of a Discovery Engine control resource
+  def to_discovery_engine_control_action
+    {
+      filter_action: {
+        filter: filter_expression,
+        data_store: Rails.configuration.discovery_engine_datastore,
+      },
+    }
+  end
 end

--- a/app/models/control/filter_action.rb
+++ b/app/models/control/filter_action.rb
@@ -1,0 +1,13 @@
+# Represents a filter action for a `Control`.
+#
+# Allows us to remove content matching a given filter expression from search results entirely.
+#
+# For example, we could temporarily remove content that has been accidentally published while the
+# problem is fixed upstream.
+#
+# see https://cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1/latest/Google-Cloud-DiscoveryEngine-V1-Control-FilterAction
+class Control::FilterAction < ApplicationRecord
+  include Control::Actionable
+
+  validates :filter_expression, presence: true
+end

--- a/app/views/common/_page_title.html.erb
+++ b/app/views/common/_page_title.html.erb
@@ -1,4 +1,9 @@
+<% context ||= nil %>
+<% context_inside ||= nil %>
+
 <%= render "govuk_publishing_components/components/title", {
-  title: title
+  title: title,
+  context:,
+  context_inside:,
 } %>
 <% content_for :page_title, title %>

--- a/app/views/controls/_boost_action.html.erb
+++ b/app/views/controls/_boost_action.html.erb
@@ -1,0 +1,13 @@
+<%= render "govuk_publishing_components/components/summary_list", {
+  title: t(".action_heading"),
+  items: [
+    {
+      field: t_model_attr(:filter_expression, on: boost_action),
+      value: boost_action.filter_expression,
+    },
+    {
+      field: t_model_attr(:boost_factor, on: boost_action),
+      value: boost_action.boost_factor
+    },
+  ]
+} %>

--- a/app/views/controls/_boost_action_fields.html.erb
+++ b/app/views/controls/_boost_action_fields.html.erb
@@ -1,0 +1,21 @@
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t_model_attr(:filter_expression, on: action)
+  },
+  id: "control_action.filter_expression",
+  name: "control[action_attributes][filter_expression]",
+  hint: t("hints.filter_expression_html"),
+  value: action.filter_expression,
+  error_items: error_items(action, :filter_expression)
+} %>
+
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t_model_attr(:boost_factor, on: action)
+  },
+  id: "control_action.boost_factor",
+  name: "control[action_attributes][boost_factor]",
+  hint: t("hints.boost_factor_html"),
+  value: action.boost_factor,
+  error_items: error_items(action, :boost_factor)
+} %>

--- a/app/views/controls/_filter_action.html.erb
+++ b/app/views/controls/_filter_action.html.erb
@@ -1,0 +1,9 @@
+<%= render "govuk_publishing_components/components/summary_list", {
+  title: t(".action_heading"),
+  items: [
+    {
+      field: t_model_attr(:filter_expression, on: filter_action),
+      value: filter_action.filter_expression,
+    },
+  ]
+} %>

--- a/app/views/controls/_filter_action_fields.html.erb
+++ b/app/views/controls/_filter_action_fields.html.erb
@@ -1,0 +1,10 @@
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t_model_attr(:filter_expression, on: action)
+  },
+  id: "control_action.filter_expression",
+  name: "control[action_attributes][filter_expression]",
+  hint: t("hints.filter_expression_html"),
+  value: action.filter_expression,
+  error_items: error_items(action, :filter_expression)
+} %>

--- a/app/views/controls/_form.html.erb
+++ b/app/views/controls/_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_with(model: control) do |f| %>
+  <% if control.errors.any? %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      id: "error-summary",
+      title: t("common.error_summary.title"),
+      description: t("common.error_summary.description", model_name: t_model_name(control.action)),
+      items: error_summary_items(control)
+    } %>
+  <% end %>
+
+  <%= f.hidden_field :action_type %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t_model_attr(:display_name)
+    },
+    id: "control_display_name",
+    name: "control[display_name]",
+    autocomplete: "off", # Stop browsers mistaking this for a "person name" field
+    value: control.display_name,
+    error_items: error_items(control, :display_name)
+  } %>
+
+  <%= render "#{control.action.to_partial_path}_fields", action: control.action %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("common.buttons.save", model_name: t_model_name),
+  } %>
+<% end %>

--- a/app/views/controls/edit.html.erb
+++ b/app/views/controls/edit.html.erb
@@ -1,0 +1,23 @@
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: t("controls.index.page_title"),
+      url: controls_path
+    },
+    {
+      title: @control.display_name_was,
+      url: control_path(@control)
+    },
+    {
+      title: t(".page_title")
+    }
+  ]
+} %>
+
+<%= render "common/page_title", {
+  title: @control.display_name_was,
+  context: t(".page_title_context", action_name: t_model_name(@control.action).capitalize),
+  context_inside: true
+} %>
+
+<%= render 'form', control: @control %>

--- a/app/views/controls/index.html.erb
+++ b/app/views/controls/index.html.erb
@@ -1,5 +1,20 @@
 <%= render "common/page_title", title: t(".page_title") %>
 
+<div class="actions">
+  <%= render "govuk_publishing_components/components/button", {
+    text: t(".buttons.new_boost_control"),
+    href: new_control_with_boost_action_path,
+    secondary: true,
+    inline_layout: true
+  } %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t(".buttons.new_filter_control"),
+    href: new_control_with_filter_action_path,
+    secondary: true,
+    inline_layout: true
+  } %>
+</div>
+
 <div class="govuk-!-margin-top-6 app-table__container" data-module="filterable-table">
   <%= render "govuk_publishing_components/components/table", {
     filterable: true,

--- a/app/views/controls/index.html.erb
+++ b/app/views/controls/index.html.erb
@@ -1,0 +1,18 @@
+<%= render "common/page_title", title: t(".page_title") %>
+
+<div class="govuk-!-margin-top-6 app-table__container" data-module="filterable-table">
+  <%= render "govuk_publishing_components/components/table", {
+    filterable: true,
+    label: t(".filter_table_label"),
+    head: [
+      { text: t_model_attr(:name) },
+      { text: t_model_attr(:action) },
+    ],
+    rows: @controls.map do |control|
+      [
+        { text: link_to(control.display_name, control, class: "govuk-link") },
+        { text: t_model_name(control.action).capitalize },
+      ]
+    end
+  } %>
+</div>

--- a/app/views/controls/new.html.erb
+++ b/app/views/controls/new.html.erb
@@ -1,0 +1,15 @@
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: t("controls.index.page_title"),
+      url: controls_path
+    },
+    {
+      title: t(".page_title", action_name: t_model_name(@control.action)),
+    }
+  ]
+} %>
+
+<%= render "common/page_title", title: t(".page_title", action_name: t_model_name(@control.action)) %>
+
+<%= render "form", control: @control %>

--- a/app/views/controls/show.html.erb
+++ b/app/views/controls/show.html.erb
@@ -1,0 +1,30 @@
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: t("controls.index.page_title"),
+      url: controls_path
+    },
+    {
+      title: @control.display_name
+    }
+  ]
+} %>
+
+<%= render "common/page_title", {
+  title: @control.display_name,
+  context: t(".page_title_context", action_name: t_model_name(@control.action).capitalize),
+  context_inside: true
+} %>
+
+
+<%= render "govuk_publishing_components/components/summary_list", {
+  title: t(".control_heading"),
+  items: [
+    {
+      field: t_model_attr(:display_name),
+      value: @control.display_name,
+    },
+  ]
+} %>
+
+<%= render @control.action %>

--- a/app/views/controls/show.html.erb
+++ b/app/views/controls/show.html.erb
@@ -17,6 +17,14 @@
 } %>
 
 
+<div class="actions">
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("common.buttons.edit", model_name: t_model_name),
+    href: edit_control_path(@control),
+    inline_layout: true
+  } %>
+</div>
+
 <%= render "govuk_publishing_components/components/summary_list", {
   title: t(".control_heading"),
   items: [

--- a/app/views/controls/show.html.erb
+++ b/app/views/controls/show.html.erb
@@ -23,6 +23,11 @@
     href: edit_control_path(@control),
     inline_layout: true
   } %>
+  <%= delete_button(
+    t("common.buttons.delete", model_name: t_model_name),
+    @control,
+    is_inline: true
+  ) %>
 </div>
 
 <%= render "govuk_publishing_components/components/summary_list", {

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,9 @@ module SearchAdmin
 
     # Use YAML to serialize data into DB columns (implicit pre Rails 7.1 behaviour)
     config.active_record.default_column_serializer = YAML
+
+    # Google Discovery Engine configuration
+    config.discovery_engine_datastore = ENV.fetch("DISCOVERY_ENGINE_DATASTORE")
+    config.discovery_engine_default_collection_name = ENV.fetch("DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME")
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,9 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Google Discovery Engine configuration
+  config.discovery_engine_datastore = "[datastore]"
+  config.discovery_engine_engine = "[engine]"
+  config.discovery_engine_serving_config = "[serving_config]"
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,13 @@ en:
         keywords: Keywords
         comment: Comments
 
+    errors:
+      models:
+        control:
+          remote_error: |
+            We couldn't save this control on Vertex AI Search because of an unexpected error.
+            This error has been logged. Please try again later.
+
   controls:
     index:
       page_title: Controls

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,19 @@ en:
         keywords: Keywords
         comment: Comments
 
+  controls:
+    index:
+      page_title: Controls
+      filter_table_label: Filter all controls
+    show:
+      page_title_context: "%{action_name} control"
+      control_heading: Control details
+      action_heading: Action details
+    filter_action:
+      action_heading: Filter action details
+    boost_action:
+      action_heading: Boost action details
+
   recommended_links:
     index:
       page_title: External links

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,6 +114,9 @@ en:
       success: The control was successfully created.
     update:
       success: The control was successfully updated.
+    destroy:
+      success: The control was successfully deleted.
+      failure: The control could not be deleted.
 
   recommended_links:
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,20 +45,39 @@ en:
       description: |
         The %{model_name} could not be saved because some fields are missing or incorrect.
 
+  attributes:
+    created_at: Created at
+    updated_at: Updated at
+
   activerecord:
     models:
+      control:
+        one: control
+        other: controls
+      control/boost_action:
+        one: boost
+        other: boost
+      control/filter_action:
+        one: filter
+        other: filter
       recommended_link:
         one: external link
         other: external links
     attributes:
+      control:
+        display_name: Name
+        action: Action
+      control/boost_action:
+        boost_factor: Boost factor
+        filter_expression: Filter expression
+      control/filter_action:
+        filter_expression: Filter expression
       recommended_link:
         link: Link
         title: Title
         description: Description
         keywords: Keywords
         comment: Comments
-        created_at: Created at
-        updated_at: Updated at
 
   recommended_links:
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,8 +107,13 @@ en:
       action_heading: Boost action details
     new:
       page_title: New %{action_name} control
+    edit:
+      page_title: Edit
+      page_title_context: "%{action_name} control"
     create:
       success: The control was successfully created.
+    update:
+      success: The control was successfully updated.
 
   recommended_links:
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,17 @@ en:
     created_at: Created at
     updated_at: Updated at
 
+  hints:
+    boost_factor_html: |
+      A decimal number between -1 and 1 that determines how much to boost (positive) or bury
+      (negative) search results by, for example <code>0.13</code>.
+    filter_expression_html: |
+      A filter query that describes which documents this adjustment applies to, for example
+      <code>link: ANY("example")</code>. Note that all fields you use in the expression must be
+      "indexable" in Discovery Engine. See <a
+      href="https://cloud.google.com/generative-ai-app-builder/docs/filter-search-metadata"
+      target="_blank" class="govuk-link">Google documentation</a> for syntax and more information.
+
   activerecord:
     models:
       control:
@@ -83,6 +94,9 @@ en:
     index:
       page_title: Controls
       filter_table_label: Filter all controls
+      buttons:
+        new_boost_control: New boost control
+        new_filter_control: New filter control
     show:
       page_title_context: "%{action_name} control"
       control_heading: Control details
@@ -91,6 +105,10 @@ en:
       action_heading: Filter action details
     boost_action:
       action_heading: Boost action details
+    new:
+      page_title: New %{action_name} control
+    create:
+      success: The control was successfully created.
 
   recommended_links:
     index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   )
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 
+  resources :controls
   resources :recommended_links, path: "/recommended-links"
 
   root "recommended_links#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,14 @@ Rails.application.routes.draw do
   )
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 
-  resources :controls
+  resources :controls, except: %i[new]
+  scope :controls, only: %i[new], as: "control" do
+    # NOTE: Rails does not accept :controller as an argument on `scope`, so we need to duplicate
+    # it in every resource definition in this scope.
+    resources :with_boost_actions, controller: :controls, action_type: Control::BoostAction
+    resources :with_filter_actions, controller: :controls, action_type: Control::FilterAction
+  end
+
   resources :recommended_links, path: "/recommended-links"
 
   root "recommended_links#index"

--- a/db/migrate/20250128074343_create_controls.rb
+++ b/db/migrate/20250128074343_create_controls.rb
@@ -1,0 +1,29 @@
+class CreateControls < ActiveRecord::Migration[8.0]
+  def change
+    create_table :controls do |t|
+      t.string :action_type, null: false
+      t.integer :action_id, null: false
+      t.string :display_name, null: false
+
+      t.timestamps
+
+      t.index %i[action_type action_id], unique: true
+    end
+
+    create_table :control_boost_actions do |t|
+      t.string :filter_expression, null: false
+      t.float :boost_factor, null: false
+
+      t.timestamps
+
+      t.check_constraint "boost_factor BETWEEN -1.0 AND 1.0 AND boost_factor != 0",
+                         name: :valid_boost_factor
+    end
+
+    create_table :control_filter_actions do |t|
+      t.string :filter_expression, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_10_114733) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_28_074343) do
+  create_table "control_boost_actions", charset: "utf8mb3", force: :cascade do |t|
+    t.string "filter_expression", null: false
+    t.float "boost_factor", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.check_constraint "(`boost_factor` between -(1.0) and 1.0) and (`boost_factor` <> 0)", name: "valid_boost_factor"
+  end
+
+  create_table "control_filter_actions", charset: "utf8mb3", force: :cascade do |t|
+    t.string "filter_expression", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "controls", charset: "utf8mb3", force: :cascade do |t|
+    t.string "action_type", null: false
+    t.integer "action_id", null: false
+    t.string "display_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["action_type", "action_id"], name: "index_controls_on_action_type_and_action_id", unique: true
+  end
+
   create_table "recommended_links", charset: "utf8mb3", force: :cascade do |t|
     t.string "title"
     t.string "link"

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -1,0 +1,29 @@
+# Controls
+## About Vertex AI Search controls
+[(Serving) controls][de-docs] are a Vertex AI Search ("Discovery Engine") feature that allows
+modifying the behaviour of our search engine by changing how queries are interpreted, or how results
+are returned.
+
+Each individual control represents a specific modification of results. There are several types of
+control ("actions") available to us, and we currently offer the following:
+- "Boosts" allow us to increase or decrease the ranking of some content items in the results by a
+  given factor
+- "Filters" allow us to remove some content items from the results entirely
+
+Both of these controls have a "filter expression" written in a Discovery Engine-specific [filter
+query language] that allows us to say which content items they apply to. For example, they could
+apply to all historic content (`is_historic = 1`), or a specific set of documents by link (`link:
+ANY("/example1", "/example2")`).
+
+## Implementation
+In Search Admin, a `Control` is the main model representing a control on Discovery Engine. It has an
+`action` associated using [delegated types], which is represented as a `Control::____Action` model
+using the `Control::Actionable` concern with the specific functionality.
+
+The action models are namespaced under the `Control` model to make clear that actions are tightly
+coupled to controls, and don't make sense as standalone units.
+
+[de-docs]: https://cloud.google.com/generative-ai-app-builder/docs/configure-serving-controls
+[delegated types]: https://api.rubyonrails.org/classes/ActiveRecord/DelegatedType.html
+[filter query language]:
+https://cloud.google.com/generative-ai-app-builder/docs/filter-search-metadata#filter-expression-syntax

--- a/spec/clients/discovery_engine/control_client_spec.rb
+++ b/spec/clients/discovery_engine/control_client_spec.rb
@@ -1,0 +1,101 @@
+RSpec.describe DiscoveryEngine::ControlClient, type: :client do
+  let(:control) { build(:control, id: 42) }
+
+  let(:discovery_engine_client) do
+    instance_double(
+      Google::Cloud::DiscoveryEngine::V1::ControlService::Client,
+      create_control: true,
+      update_control: true,
+      delete_control: true,
+    )
+  end
+
+  before do
+    allow(Google::Cloud::DiscoveryEngine)
+      .to receive(:control_service).and_return(discovery_engine_client)
+  end
+
+  describe "#create" do
+    it "creates the control on Discovery Engine" do
+      expect(discovery_engine_client).to receive(:create_control).with(
+        control: control.to_discovery_engine_control,
+        control_id: "search-admin-42",
+        parent: "[engine]",
+      )
+
+      subject.create(control) # rubocop:disable Rails/SaveBang (not an ActiveRecord model)
+    end
+  end
+
+  describe "#update" do
+    it "updates the control on Discovery Engine" do
+      expect(discovery_engine_client).to receive(:update_control).with(
+        control: control.to_discovery_engine_control,
+      )
+
+      subject.update(control) # rubocop:disable Rails/SaveBang (not an ActiveRecord model)
+    end
+
+    context "when the operation raises an arbitrary error" do
+      before do
+        allow(discovery_engine_client).to receive(:update_control).and_raise(Google::Cloud::Error)
+      end
+
+      it "raises a ClientInternalError and adds a base validation error" do
+        expect { subject.update(control) }.to raise_error(ClientError)
+
+        expect(control.errors).to be_of_kind(:base, :remote_error)
+      end
+    end
+
+    context "when the operation raises an invalid argument error about filter expressions" do
+      before do
+        allow(discovery_engine_client)
+          .to receive(:update_control)
+          .and_raise(Google::Cloud::InvalidArgumentError, "The filter syntax is broken")
+      end
+
+      it "raises a ClientInternalError and adds a field validation error on action" do
+        expect { subject.update(control) }.to raise_error(ClientError)
+
+        expect(control.action.errors).to be_of_kind(:filter_expression, :invalid)
+      end
+    end
+
+    context "when the operation raises an invalid argument error about anything else" do
+      before do
+        allow(discovery_engine_client)
+          .to receive(:update_control)
+          .and_raise(Google::Cloud::InvalidArgumentError, "The splines are unreticulated")
+      end
+
+      it "raises a ClientInternalError and adds a base validation error" do
+        expect { subject.update(control) }.to raise_error(ClientError)
+
+        expect(control.errors).to be_of_kind(:base, :remote_error)
+      end
+    end
+  end
+
+  describe "#delete" do
+    it "deletes the control on Discovery Engine" do
+      expect(discovery_engine_client).to receive(:delete_control).with(
+        name: "[engine]/controls/search-admin-42",
+      )
+
+      subject.delete(control)
+    end
+
+    context "when the operation raises an arbitrary error" do
+      before do
+        allow(discovery_engine_client).to receive(:delete_control).and_raise(Google::Cloud::Error)
+      end
+
+      it "raises a ClientInternalError and adds a base validation error" do
+        expect { subject.delete(control) }.to raise_error(ClientError)
+
+        expect(control.errors).to be_of_kind(:base, :remote_error)
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,22 @@
 FactoryBot.define do
-  factory :control do
+  # Unlike fixtures, record instances created through FactoryBot go through the full Rails callback
+  # lifecycle on creation. That is often desirable, but not in the case of our models using the
+  # `RemoteSynchronizable` concern to create counterparts on remote APIs automatically whenever you
+  # create a new record.
+  #
+  # This trait sets the `skip_remote_synchronization_on_create` flag to true on records created
+  # through factories that include it, so that this behaviour is skipped.
+  #
+  # If you _do_ want to specifically test remote synchronization on a record, you can override this
+  # manually when you build your model using `FactoryBot.build`:
+  # ```ruby
+  # build(:my_model, skip_remote_synchronization_on_create: false)
+  # ```
+  trait :remote_synchronizable do
+    skip_remote_synchronization_on_create { true }
+  end
+
+  factory :control, traits: %i[remote_synchronizable] do
     display_name { "Control" }
 
     action factory: :control_boost_action

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,27 @@
 FactoryBot.define do
+  factory :control do
+    display_name { "Control" }
+
+    action factory: :control_boost_action
+
+    trait :with_boost_action do
+      action factory: :control_boost_action
+    end
+
+    trait :with_filter_action do
+      action factory: :control_filter_action
+    end
+  end
+
+  factory :control_boost_action, class: Control::BoostAction do
+    filter_expression { 'link: ANY("/example")' }
+    boost_factor { 0.13 }
+  end
+
+  factory :control_filter_action, class: Control::FilterAction do
+    filter_expression { 'link: ANY("/example")' }
+  end
+
   factory :recommended_link do
     title { "Tax online" }
     link { "https://www.tax.service.gov.uk/" }

--- a/spec/models/control/boost_action_spec.rb
+++ b/spec/models/control/boost_action_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Control::BoostAction, type: :model do
+  describe "validations" do
+    subject(:action) { build(:control_boost_action) }
+
+    it { is_expected.to be_valid }
+
+    context "without a filter expression" do
+      before do
+        action.filter_expression = nil
+      end
+
+      it "is invalid" do
+        expect(action).to be_invalid
+        expect(action.errors).to be_of_kind(:filter_expression, :blank)
+      end
+    end
+
+    context "without a boost factor" do
+      before do
+        action.boost_factor = nil
+      end
+
+      it "is invalid" do
+        expect(action).to be_invalid
+        expect(action.errors).to be_of_kind(:boost_factor, :not_a_number)
+      end
+    end
+
+    context "with an out of range boost factor" do
+      before do
+        action.boost_factor = 1.1
+      end
+
+      it "is invalid" do
+        expect(action).to be_invalid
+        expect(action.errors).to be_of_kind(:boost_factor, :in)
+      end
+    end
+
+    context "with a zero boost factor" do
+      before do
+        action.boost_factor = 0
+      end
+
+      it "is invalid" do
+        expect(action).to be_invalid
+        expect(action.errors).to be_of_kind(:boost_factor, :other_than)
+      end
+    end
+  end
+end

--- a/spec/models/control/boost_action_spec.rb
+++ b/spec/models/control/boost_action_spec.rb
@@ -48,4 +48,20 @@ RSpec.describe Control::BoostAction, type: :model do
       end
     end
   end
+
+  describe "#to_discovery_engine_control_action" do
+    subject(:boost) do
+      build_stubbed(:control_boost_action, filter_expression: "foo = 1", boost_factor: 0.13)
+    end
+
+    it "returns a representation of the action for Discovery Engine" do
+      expect(boost.to_discovery_engine_control_action).to eq({
+        boost_action: {
+          filter: "foo = 1",
+          boost: 0.13,
+          data_store: "[datastore]",
+        },
+      })
+    end
+  end
 end

--- a/spec/models/control/filter_action_spec.rb
+++ b/spec/models/control/filter_action_spec.rb
@@ -15,4 +15,17 @@ RSpec.describe Control::FilterAction, type: :model do
       end
     end
   end
+
+  describe "#to_discovery_engine_control_action" do
+    subject(:filter) { build_stubbed(:control_filter_action, filter_expression: "foo = 1") }
+
+    it "returns a representation of the action for Discovery Engine" do
+      expect(filter.to_discovery_engine_control_action).to eq({
+        filter_action: {
+          filter: "foo = 1",
+          data_store: "[datastore]",
+        },
+      })
+    end
+  end
 end

--- a/spec/models/control/filter_action_spec.rb
+++ b/spec/models/control/filter_action_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Control::FilterAction, type: :model do
+  describe "validations" do
+    subject(:action) { build(:control_filter_action) }
+
+    it { is_expected.to be_valid }
+
+    context "without a filter expression" do
+      before do
+        action.filter_expression = nil
+      end
+
+      it "is invalid" do
+        expect(action).to be_invalid
+        expect(action.errors).to be_of_kind(:filter_expression, :blank)
+      end
+    end
+  end
+end

--- a/spec/models/control_spec.rb
+++ b/spec/models/control_spec.rb
@@ -26,4 +26,42 @@ RSpec.describe Control, type: :model do
       end
     end
   end
+
+  describe "Discovery Engine representation" do
+    subject(:control) { build_stubbed(:control, id: 42, display_name: "My boost control", action:) }
+
+    let(:action) { build(:control_boost_action) }
+
+    describe "#discovery_engine_id" do
+      it "builds an ID from the control's database ID" do
+        expect(control.discovery_engine_id).to eq("search-admin-42")
+      end
+    end
+
+    describe "#parent" do
+      it "is the configured engine" do
+        expect(control.parent).to eq("[engine]")
+      end
+    end
+
+    describe "#name" do
+      it "returns the fully qualified name of the control" do
+        expect(control.name).to eq("[engine]/controls/search-admin-42")
+      end
+    end
+
+    describe "#to_discovery_engine_control" do
+      it "returns a representation of the control for Discovery Engine" do
+        expect(control.to_discovery_engine_control).to include(
+          name: "[engine]/controls/search-admin-42",
+          display_name: "My boost control",
+          # We don't care what's in the action (that's tested elsewhere), but we do care that the
+          # key is present
+          boost_action: hash_including,
+          solution_type: Google::Cloud::DiscoveryEngine::V1::SolutionType::SOLUTION_TYPE_SEARCH,
+          use_cases: [Google::Cloud::DiscoveryEngine::V1::SearchUseCase::SEARCH_USE_CASE_SEARCH],
+        )
+      end
+    end
+  end
 end

--- a/spec/models/control_spec.rb
+++ b/spec/models/control_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Control, type: :model do
+  it_behaves_like "RemoteSynchronizable", DiscoveryEngine::ControlClient
+
   describe "validations" do
     subject(:control) { build(:control) }
 

--- a/spec/models/control_spec.rb
+++ b/spec/models/control_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Control, type: :model do
+  describe "validations" do
+    subject(:control) { build(:control) }
+
+    it { is_expected.to be_valid }
+
+    context "without a display name" do
+      before do
+        control.display_name = nil
+      end
+
+      it "is invalid" do
+        expect(control).to be_invalid
+        expect(control.errors).to be_of_kind(:display_name, :blank)
+      end
+    end
+
+    context "without an action" do
+      before do
+        control.action = nil
+      end
+
+      it "is invalid" do
+        expect(control).to be_invalid
+        expect(control.errors).to be_of_kind(:action, :blank)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,13 @@ ActiveRecord::Migration.maintain_test_schema!
 require "webmock/rspec"
 WebMock.disable_net_connect!
 
+require "grpc_mock/rspec"
+GrpcMock.disable_net_connect!
+
+# Required to be able to mock Google classes in tests (as classes from the `v1` namespace are not
+# used directly in non-test code, they are not loaded by the gem's lazy loading)
+require "google/cloud/discovery_engine/v1"
+
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.disable_monkey_patching!

--- a/spec/support/shared_examples/concerns/remote_synchronizable.rb
+++ b/spec/support/shared_examples/concerns/remote_synchronizable.rb
@@ -1,0 +1,83 @@
+RSpec.shared_examples "RemoteSynchronizable" do |client_class|
+  let(:client) do
+    instance_double(client_class, create: true, update: true, delete: true)
+  end
+  let(:factory) { described_class.model_name.param_key }
+
+  before do
+    allow(client_class).to receive(:new).and_return(client)
+  end
+
+  describe "when creating a new record" do
+    subject(:record) { build(factory, skip_remote_synchronization_on_create: false) }
+
+    it "creates the remote resource using the client" do
+      record.save!
+
+      expect(client).to have_received(:create).with(record)
+    end
+
+    context "when the remote resource creation fails" do
+      let(:error) { ClientError.new("Uh oh") }
+
+      before do
+        allow(client).to receive(:create).and_raise(error)
+
+        record.save # rubocop:disable Rails/SaveBang (we're checking record state)
+      end
+
+      it "stops the record from being created" do
+        expect(record).not_to be_persisted
+      end
+    end
+  end
+
+  describe "when updating an existing record" do
+    subject(:record) { create(factory) }
+
+    it "updates the remote resource" do
+      record.save!
+
+      expect(client).to have_received(:update).with(record)
+    end
+
+    context "when the remote resource update fails" do
+      let(:error) { ClientError.new("Uh oh") }
+
+      before do
+        allow(client).to receive(:update).and_raise(error)
+
+        record.updated_at = Time.current # change something so we can check it won't save
+        record.save # rubocop:disable Rails/SaveBang (we're checking record state)
+      end
+
+      it "stops the record from being persisted" do
+        expect(record).to be_changed
+      end
+    end
+  end
+
+  describe "when destroying an existing record" do
+    subject(:record) { create(factory) }
+
+    it "deletes the remote resource" do
+      record.destroy!
+
+      expect(client).to have_received(:delete).with(record)
+    end
+
+    context "when the remote resource deletion fails with an internal error" do
+      let(:error) { ClientError.new("Uh oh") }
+
+      before do
+        allow(client).to receive(:delete).and_raise(error)
+
+        record.destroy # rubocop:disable Rails/SaveBang (we're checking record state)
+      end
+
+      it "stops the record from being destroyed" do
+        expect(described_class.exists?(record.id)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/system/controls_spec.rb
+++ b/spec/system/controls_spec.rb
@@ -1,4 +1,12 @@
 RSpec.describe "Controls", type: :system do
+  let(:control) do
+    instance_double(DiscoveryEngine::ControlClient, create: true, update: true, delete: true)
+  end
+
+  before do
+    allow(DiscoveryEngine::ControlClient).to receive(:new).and_return(control)
+  end
+
   scenario "Viewing controls" do
     given_several_controls_exist
 

--- a/spec/system/controls_spec.rb
+++ b/spec/system/controls_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe "Controls", type: :system do
+  scenario "Viewing controls" do
+    given_several_controls_exist
+
+    when_i_visit_the_controls_page
+    then_i_should_see_all_controls
+    and_i_can_click_through_to_a_control
+  end
+
+  def given_several_controls_exist
+    @boost = create(:control, :with_boost_action, display_name: "My boost")
+    @filter = create(:control, :with_filter_action, display_name: "My filter")
+  end
+
+  def when_i_visit_the_controls_page
+    visit controls_path
+  end
+
+  def then_i_should_see_all_controls
+    expect(page).to have_content("My boost Boost")
+    expect(page).to have_content("My filter Filter")
+  end
+
+  def and_i_can_click_through_to_a_control
+    click_link "My boost", match: :first
+    expect(page).to have_selector("h1", text: "My boost")
+  end
+end

--- a/spec/system/controls_spec.rb
+++ b/spec/system/controls_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe "Controls", type: :system do
 
     then_the_control_has_been_updated
     and_i_can_see_the_updated_boost_control_details
+
+    when_i_choose_to_delete_the_control
+    then_the_control_has_been_deleted
   end
 
   scenario "Managing filter controls" do
@@ -35,6 +38,9 @@ RSpec.describe "Controls", type: :system do
 
     then_the_control_has_been_updated
     and_i_can_see_the_updated_filter_control_details
+
+    when_i_choose_to_delete_the_control
+    then_the_control_has_been_deleted
   end
 
   def given_several_controls_exist
@@ -130,5 +136,14 @@ RSpec.describe "Controls", type: :system do
     expect(page).to have_selector("h1", text: "Filter control My updated filter control")
     expect(page).to have_content("Name My updated filter control")
     expect(page).to have_content("Filter expression is_really_cool = 999")
+  end
+
+  def when_i_choose_to_delete_the_control
+    click_button "Delete control"
+  end
+
+  def then_the_control_has_been_deleted
+    expect(page).to have_content("control was successfully deleted")
+    expect(Control.count).to eq(0)
   end
 end

--- a/spec/system/controls_spec.rb
+++ b/spec/system/controls_spec.rb
@@ -7,6 +7,24 @@ RSpec.describe "Controls", type: :system do
     and_i_can_click_through_to_a_control
   end
 
+  scenario "Managing boost controls" do
+    when_i_visit_the_controls_page
+    and_i_choose_to_create_a_new_boost_control
+    and_i_submit_the_form_with_boost_control_details
+
+    then_my_control_has_been_created
+    and_i_can_see_the_boost_control_details
+  end
+
+  scenario "Managing filter controls" do
+    when_i_visit_the_controls_page
+    and_i_choose_to_create_a_new_filter_control
+    and_i_submit_the_form_with_filter_control_details
+
+    then_my_control_has_been_created
+    and_i_can_see_the_filter_control_details
+  end
+
   def given_several_controls_exist
     @boost = create(:control, :with_boost_action, display_name: "My boost")
     @filter = create(:control, :with_filter_action, display_name: "My filter")
@@ -24,5 +42,45 @@ RSpec.describe "Controls", type: :system do
   def and_i_can_click_through_to_a_control
     click_link "My boost", match: :first
     expect(page).to have_selector("h1", text: "My boost")
+  end
+
+  def and_i_choose_to_create_a_new_boost_control
+    click_link "New boost control"
+  end
+
+  def and_i_choose_to_create_a_new_filter_control
+    click_link "New filter control"
+  end
+
+  def and_i_submit_the_form_with_boost_control_details
+    fill_in "Name", with: "My boost control"
+    fill_in "Filter expression", with: "is_cool = 1"
+    fill_in "Boost factor", with: "0.42"
+
+    click_button "Save control"
+  end
+
+  def and_i_submit_the_form_with_filter_control_details
+    fill_in "Name", with: "My filter control"
+    fill_in "Filter expression", with: "is_cool = 1"
+
+    click_button "Save control"
+  end
+
+  def then_my_control_has_been_created
+    expect(Control.count).to eq(1)
+  end
+
+  def and_i_can_see_the_boost_control_details
+    expect(page).to have_selector("h1", text: "Boost control My boost control")
+    expect(page).to have_content("Name My boost control")
+    expect(page).to have_content("Filter expression is_cool = 1")
+    expect(page).to have_content("Boost factor 0.42")
+  end
+
+  def and_i_can_see_the_filter_control_details
+    expect(page).to have_selector("h1", text: "Filter control My filter control")
+    expect(page).to have_content("Name My filter control")
+    expect(page).to have_content("Filter expression is_cool = 1")
   end
 end

--- a/spec/system/controls_spec.rb
+++ b/spec/system/controls_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe "Controls", type: :system do
 
     then_my_control_has_been_created
     and_i_can_see_the_boost_control_details
+
+    when_i_choose_to_edit_the_control
+    and_i_submit_the_form_with_updated_boost_control_details
+
+    then_the_control_has_been_updated
+    and_i_can_see_the_updated_boost_control_details
   end
 
   scenario "Managing filter controls" do
@@ -23,6 +29,12 @@ RSpec.describe "Controls", type: :system do
 
     then_my_control_has_been_created
     and_i_can_see_the_filter_control_details
+
+    when_i_choose_to_edit_the_control
+    and_i_submit_the_form_with_updated_filter_control_details
+
+    then_the_control_has_been_updated
+    and_i_can_see_the_updated_filter_control_details
   end
 
   def given_several_controls_exist
@@ -82,5 +94,41 @@ RSpec.describe "Controls", type: :system do
     expect(page).to have_selector("h1", text: "Filter control My filter control")
     expect(page).to have_content("Name My filter control")
     expect(page).to have_content("Filter expression is_cool = 1")
+  end
+
+  def when_i_choose_to_edit_the_control
+    click_link "Edit control"
+  end
+
+  def and_i_submit_the_form_with_updated_boost_control_details
+    fill_in "Name", with: "My updated boost control"
+    fill_in "Filter expression", with: "is_really_cool = 999"
+    fill_in "Boost factor", with: "0.999"
+
+    click_button "Save control"
+  end
+
+  def and_i_submit_the_form_with_updated_filter_control_details
+    fill_in "Name", with: "My updated filter control"
+    fill_in "Filter expression", with: "is_really_cool = 999"
+
+    click_button "Save control"
+  end
+
+  def then_the_control_has_been_updated
+    expect(page).to have_content("control was successfully updated")
+  end
+
+  def and_i_can_see_the_updated_boost_control_details
+    expect(page).to have_selector("h1", text: "Boost control My updated boost control")
+    expect(page).to have_content("Name My updated boost control")
+    expect(page).to have_content("Filter expression is_really_cool = 999")
+    expect(page).to have_content("Boost factor 0.999")
+  end
+
+  def and_i_can_see_the_updated_filter_control_details
+    expect(page).to have_selector("h1", text: "Filter control My updated filter control")
+    expect(page).to have_content("Name My updated filter control")
+    expect(page).to have_content("Filter expression is_really_cool = 999")
   end
 end


### PR DESCRIPTION
This adds the ability to manage **controls** to Search Admin.

> [!note]
> This supersedes PR #1344 with an improved domain model design for controls based on Rails's [delegated types].

## About controls

[(Serving) controls][controls] are a Vertex AI Search ("Discovery Engine") feature that allows modifying the behaviour of our search engine by changing how queries are interpreted, or how results are returned.

Each individual control represents a specific modification of results. There are several types of control ("actions") available to us, and in this change we introduce the first two:
- "Boosts" allow us to increase or decrease the ranking of some content items in the results by a factor
- "Filters" allow us to remove some content items from the results entirely

Both of these controls have a "filter expression" written in a Discovery Engine-specific [filter query language] that allows us to say which content items they apply to. For example, they could apply to all historic content (`is_historic = 1`), or a specific set of documents by link (`link: ANY("/example1", "/example2")`).

## PR changes

This PR adds a basic CRUD UI for boosts and filters to the application, as well as synchronisation to Discovery Engine.

A `Control` is the main model representing a control on Discovery Engine. It has an `action` associated using [delegated types], which is represented as a `BoostAction` or `FilterAction` model with the specific functionality (namespaced under the `Control` model to make clear that actions are tightly coupled to controls and don't make sense as standalone units).

Due to much of the controller and view logic being shared between different subtypes, we can have a generic `ControlsController` and generic view templates doing all the heavy lifting, other than some logic to determine what kind of action to attach to the `Control` on first creation, as well as a lightweight partial each for the form and displaying an individual filter or boost.

For the synchronisation, this PR introduces a `RemoteSynchronizable` concern that enhances `Control` (and other models in the future) with the ability to sync as part of lifecycle events using a client that implements the API calls to Discovery Engine.

Normally, we'd be wary of making API calls synchronously as part of model callbacks, but in this case, the remote persistence is a core part of our domain model given that Search Admin is for all intents and purposes a shiny UI for a remote API.

## Screenshots
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/21c1983f-ef1a-41af-8e50-3f2f086b76e9" />

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/01c78e9e-2871-46df-bdc8-f7f748d04416" />

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/9dc875a5-0032-4e56-b494-211ae9208197" />

<img width="852" alt="Screenshot 2025-02-03 at 13 28 47" src="https://github.com/user-attachments/assets/b69dcbbd-e46d-439b-a8f3-158f6b25639d" />

## Deferred work

This is the first iteration of this feature, and the following are not part of this PR to avoid it getting too big:

- a more user-friendly UI
- activating controls on Discovery Engine by attaching them to a serving configuration (needs some infrastructure work to create a new serving configuration)
- auditing and commenting functionality for admin users (this makes sense to do as shared functionality between this and other models in the future)

[controls]: https://cloud.google.com/generative-ai-app-builder/docs/configure-serving-controls
[delegated types]: https://api.rubyonrails.org/classes/ActiveRecord/DelegatedType.html
[filter query language]: https://cloud.google.com/generative-ai-app-builder/docs/filter-search-metadata#filter-expression-syntax