### PR TITLE
Change title to heading and fix vertical spacing

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,7 +20,6 @@
 @import 'govuk_publishing_components/components/summary-list';
 @import 'govuk_publishing_components/components/table';
 @import 'govuk_publishing_components/components/textarea';
-@import 'govuk_publishing_components/components/title';
 
 .actions {
   margin-bottom: govuk-spacing(6);

--- a/app/views/common/_page_title.html.erb
+++ b/app/views/common/_page_title.html.erb
@@ -1,9 +1,12 @@
 <% context ||= nil %>
 <% context_inside ||= nil %>
 
-<%= render "govuk_publishing_components/components/title", {
-  title: title,
+<%= render "govuk_publishing_components/components/heading", {
+  text: title,
   context:,
   context_inside:,
+  heading_level: 1,
+  font_size: "xl",
+  margin_bottom: 8,
 } %>
 <% content_for :page_title, title %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,8 @@
     navigation_items: navigation_items
   } %>
   <div class="govuk-width-container">
-    <main class="govuk-main-wrapper govuk-!-padding-top-2" id="main-content" role="main">
+    <%= @breadcrumbs %>
+    <main class="govuk-main-wrapper" id="main-content" role="main">
       <% flash.each do |type, msg| %>
         <% if type == 'notice' %>
           <%= render "govuk_publishing_components/components/success_alert", {

--- a/app/views/recommended_links/edit.html.erb
+++ b/app/views/recommended_links/edit.html.erb
@@ -1,18 +1,20 @@
-<%= render "govuk_publishing_components/components/breadcrumbs", {
-  breadcrumbs: [
-    {
-      title: t("recommended_links.index.page_title"),
-      url: recommended_links_path
-    },
-    {
-      title: @recommended_link.title_was,
-      url: recommended_link_path(@recommended_link)
-    },
-    {
-      title: t(".page_title")
-    }
-  ]
-} %>
+<% @breadcrumbs = capture do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: t("recommended_links.index.page_title"),
+        url: recommended_links_path
+      },
+      {
+        title: @recommended_link.title_was,
+        url: recommended_link_path(@recommended_link)
+      },
+      {
+        title: t(".page_title")
+      }
+    ]
+  } %>
+<% end %>
 
 <%= render "common/page_title", title: @recommended_link.title_was %>
 

--- a/app/views/recommended_links/new.html.erb
+++ b/app/views/recommended_links/new.html.erb
@@ -1,14 +1,16 @@
-<%= render "govuk_publishing_components/components/breadcrumbs", {
-  breadcrumbs: [
-    {
-      title: t("recommended_links.index.page_title"),
-      url: recommended_links_path
-    },
-    {
-      title: t(".page_title")
-    }
-  ]
-} %>
+<% @breadcrumbs = capture do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: t("recommended_links.index.page_title"),
+        url: recommended_links_path
+      },
+      {
+        title: t(".page_title")
+      }
+    ]
+  } %>
+<% end %>
 
 <%= render "common/page_title", title: t(".page_title") %>
 

--- a/app/views/recommended_links/show.html.erb
+++ b/app/views/recommended_links/show.html.erb
@@ -1,14 +1,16 @@
-<%= render "govuk_publishing_components/components/breadcrumbs", {
-  breadcrumbs: [
-    {
-      title: t("recommended_links.index.page_title"),
-      url: recommended_links_path
-    },
-    {
-      title: @recommended_link.title
-    }
-  ]
-} %>
+<% @breadcrumbs = capture do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: t("recommended_links.index.page_title"),
+        url: recommended_links_path
+      },
+      {
+        title: @recommended_link.title
+      }
+    ]
+  } %>
+<% end %>
 
 <%= render "common/page_title", title: @recommended_link.title %>
 


### PR DESCRIPTION
## What
Replace title component with heading in the main view.

## Why
We are attempting to retire the page title component in favour of the heading component. [Trello](https://trello.com/c/3s7kqTFf/466-replace-title-with-heading-in-search-admin)

## Before and After views:
| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/aa507d40-3a2a-4027-8d75-5dafb8395e4d)  | ![image](https://github.com/user-attachments/assets/07ae88a6-37ce-4365-9377-c7ed8522b4c7)   |