### PR TITLE
Re-add Sidekiq to application

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "bootsnap", require: false
 gem "csv"
 gem "dartsass-rails"
 gem "mysql2"
+gem "sentry-sidekiq"
 gem "sprockets-rails"
 
 # GDS managed gems
@@ -14,6 +15,7 @@ gem "gds-sso"
 gem "google-cloud-discovery_engine"
 gem "govuk_app_config"
 gem "govuk_publishing_components"
+gem "govuk_sidekiq"
 gem "mail-notify"
 gem "plek"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,6 +221,11 @@ GEM
     govuk_schemas (5.0.4)
       faker (~> 3.4.1)
       json-schema (>= 2.8, < 4.4)
+    govuk_sidekiq (9.0.5)
+      gds-api-adapters (>= 19.1.0)
+      govuk_app_config (>= 1.1)
+      redis-client (>= 0.22.2)
+      sidekiq (~> 7.0, < 8)
     govuk_test (4.1.0)
       brakeman (>= 5.0.2)
       capybara (>= 3.36)
@@ -599,6 +604,8 @@ GEM
       ffi (~> 1.0)
     rdoc (6.11.0)
       psych (>= 4.0.0)
+    redis-client (0.23.2)
+      connection_pool
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -676,6 +683,15 @@ GEM
     sentry-ruby (5.22.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.22.3)
+      sentry-ruby (~> 5.22.3)
+      sidekiq (>= 3.0)
+    sidekiq (7.3.8)
+      base64
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -713,7 +729,7 @@ GEM
       rack (>= 2.0.9)
     warden-oauth2 (0.0.1)
       warden
-    webmock (3.24.0)
+    webmock (3.25.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -742,6 +758,7 @@ DEPENDENCIES
   govuk_app_config
   govuk_publishing_components
   govuk_schemas
+  govuk_sidekiq
   govuk_test
   grpc_mock
   listen
@@ -752,6 +769,7 @@ DEPENDENCIES
   rails (= 8.0.1)
   rspec-rails
   rubocop-govuk
+  sentry-sidekiq
   simplecov
   sprockets-rails
   webmock

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: bin/rails server --restart
+worker: bundle exec sidekiq -C ./config/sidekiq.yml
 css: bin/rails dartsass:watch

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,2 @@
+# We don't currently need to override any Sidekiq defaults, but the GOV.UK Kubernetes Platform
+# expects this file to exist for any app that uses Sidekiq.


### PR DESCRIPTION
This was removed due to a misunderstanding around this app not using Sidekiq (we removed some old code in advance of rebuilding it, and the app thus temporarily did not use Sidekiq).