### PR TITLE
Use `Data.define` for `DataStore` and `Engine`

### DIFF
--- a/app/models/data_store.rb
+++ b/app/models/data_store.rb
@@ -6,23 +6,10 @@
 # data stores through Search Admin.
 #
 # see https://cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1/latest/Google-Cloud-DiscoveryEngine-V1-DataStore
-class DataStore
+DataStore = Data.define(:remote_resource_id) do
   include DiscoveryEngineNameable
 
-  # The ID of the default datastore created through Terraform in `govuk_infrastructure`
-  DEFAULT_DATA_STORE_ID = "govuk_content".freeze
-
-  attr_reader :remote_resource_id
-
   def self.default
-    new(DEFAULT_DATA_STORE_ID)
-  end
-
-  def initialize(remote_resource_id)
-    @remote_resource_id = remote_resource_id
-  end
-
-  def ==(other)
-    remote_resource_id == other.remote_resource_id
+    new("govuk_content")
   end
 end

--- a/app/models/engine.rb
+++ b/app/models/engine.rb
@@ -8,23 +8,11 @@
 # engines through Search Admin.
 #
 # see https://cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1/latest/Google-Cloud-DiscoveryEngine-V1-Engine
-class Engine
+Engine = Data.define(:remote_resource_id) do
   include DiscoveryEngineNameable
 
-  # The ID of the default engine created through Terraform in `govuk-infrastructure`
-  DEFAULT_ENGINE_ID = "govuk".freeze
-
-  attr_reader :remote_resource_id
-
+  # The default engine created through Terraform in `govuk-infrastructure`
   def self.default
-    new(DEFAULT_ENGINE_ID)
-  end
-
-  def initialize(remote_resource_id)
-    @remote_resource_id = remote_resource_id
-  end
-
-  def ==(other)
-    remote_resource_id == other.remote_resource_id
+    new("govuk")
   end
 end


### PR DESCRIPTION
These are atomic value objects at the end of the day, and `Data.define` allows us to do away with having to manually define an initializer, attribute reader, and equality operator.