### PR TITLE
Update app navigation

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
 @import 'govuk_publishing_components/components/layout-for-admin';
 @import 'govuk_publishing_components/components/layout-header';
 @import 'govuk_publishing_components/components/search';
+@import 'govuk_publishing_components/components/secondary-navigation';
 @import 'govuk_publishing_components/components/skip-link';
 @import 'govuk_publishing_components/components/success-alert';
 @import 'govuk_publishing_components/components/summary-list';

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include AuthenticatesUser
+  include HasNavigationAreas
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/concerns/has_navigation_areas.rb
+++ b/app/controllers/concerns/has_navigation_areas.rb
@@ -7,8 +7,8 @@ module HasNavigationAreas
   extend ActiveSupport::Concern
 
   included do
-    class_attribute :primary_navigation_area
+    class_attribute :primary_navigation_area, :secondary_navigation_area
 
-    helper_method :primary_navigation_area
+    helper_method :primary_navigation_area, :secondary_navigation_area
   end
 end

--- a/app/controllers/concerns/has_navigation_areas.rb
+++ b/app/controllers/concerns/has_navigation_areas.rb
@@ -1,0 +1,14 @@
+# Enhances a controller with the ability to set "navigation areas" via class attributes.
+#
+# This allows a controller to define that it is part of a certain area of the app for navigation
+# purposes, either by setting the class attribute on the controller, or more dynamically by defining
+# a method.
+module HasNavigationAreas
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :primary_navigation_area
+
+    helper_method :primary_navigation_area
+  end
+end

--- a/app/controllers/controls_controller.rb
+++ b/app/controllers/controls_controller.rb
@@ -1,6 +1,10 @@
 class ControlsController < ApplicationController
   before_action :set_control, only: %i[show edit update destroy]
 
+  self.primary_navigation_area = :search
+  self.secondary_navigation_area = :controls
+  layout "search"
+
   def index
     @controls = Control.includes(:action).order(:display_name)
   end

--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -1,7 +1,9 @@
 class RecommendedLinksController < ApplicationController
   before_action :set_recommended_link, only: %i[show edit update destroy]
 
-  self.primary_navigation_area = :recommended_links
+  self.primary_navigation_area = :search
+  self.secondary_navigation_area = :recommended_links
+  layout "search"
 
   def index
     @recommended_links = RecommendedLink.order([:link])

--- a/app/controllers/recommended_links_controller.rb
+++ b/app/controllers/recommended_links_controller.rb
@@ -1,6 +1,8 @@
 class RecommendedLinksController < ApplicationController
   before_action :set_recommended_link, only: %i[show edit update destroy]
 
+  self.primary_navigation_area = :recommended_links
+
   def index
     @recommended_links = RecommendedLink.order([:link])
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,26 +1,2 @@
 module ApplicationHelper
-  def navigation_items
-    return [] unless Current.user?
-
-    [
-      {
-        text: t("recommended_links.index.page_title"),
-        href: recommended_links_path,
-        active: controller.controller_name == "recommended_links",
-      },
-      {
-        text: t("controls.index.page_title"),
-        href: controls_path,
-        active: controller.controller_name == "controls",
-      },
-      {
-        text: Current.user.name,
-        href: Plek.new.external_url_for("signon"),
-      },
-      {
-        text: t("common.menu.sign_out"),
-        href: "/auth/gds/sign_out",
-      },
-    ]
-  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,26 @@
   <%= render "govuk_publishing_components/components/layout_header", {
     product_name: t("common.product_name"),
     environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
-    navigation_items: navigation_items
+    navigation_items: [
+      {
+        text: t("recommended_links.index.page_title"),
+        href: recommended_links_path,
+        active: primary_navigation_area == :recommended_links,
+      },
+      {
+        text: t("controls.index.page_title"),
+        href: controls_path,
+        active: primary_navigation_area == :controls,
+      },
+      {
+        text: Current.user.name,
+        href: Plek.new.external_url_for("signon"),
+      },
+      {
+        text: t("common.menu.sign_out"),
+        href: "/auth/gds/sign_out",
+      },
+    ]
   } %>
   <div class="govuk-width-container">
     <%= yield :breadcrumbs %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,14 +15,9 @@
     environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
     navigation_items: [
       {
-        text: t("recommended_links.index.page_title"),
+        text: t("primary_navigation_areas.search"),
         href: recommended_links_path,
-        active: primary_navigation_area == :recommended_links,
-      },
-      {
-        text: t("controls.index.page_title"),
-        href: controls_path,
-        active: primary_navigation_area == :controls,
+        active: primary_navigation_area == :search,
       },
       {
         text: Current.user.name,
@@ -35,6 +30,8 @@
     ]
   } %>
   <div class="govuk-width-container">
+    <%= yield :secondary_nav %>
+
     <%= yield :breadcrumbs %>
 
     <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/app/views/layouts/search.html.erb
+++ b/app/views/layouts/search.html.erb
@@ -1,0 +1,19 @@
+<% content_for :secondary_nav do %>
+  <%= render "govuk_publishing_components/components/secondary_navigation", {
+    aria_label: "Search secondary navigation",
+    items: [
+      {
+        label: t("recommended_links.index.page_title"),
+        href: recommended_links_path,
+        current: secondary_navigation_area == :recommended_links,
+      },
+      {
+        label: t("controls.index.page_title"),
+        href: controls_path,
+        current: secondary_navigation_area == :controls,
+      },
+    ]
+  } %>
+<% end %>
+
+<%= render template: "layouts/application" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,9 @@ en:
       description: |
         The %{model_name} could not be saved because some fields are missing or incorrect.
 
+  primary_navigation_areas:
+    search: Search
+
   attributes:
     created_at: Created at
     updated_at: Updated at


### PR DESCRIPTION
This reworks Search Admin's navigation to be on two levels: discrete primary areas (such as "Search", and in the future, "Autocomplete"), and a secondary level of navigation within those areas.

It also refactors the navigation code to make the controller declare what area it is in, instead of a helper checking the active controller.

<img width="979" alt="image" src="https://github.com/user-attachments/assets/b42de2ee-c654-4ea1-9401-b6b664141957" />
