### PR TITLE
Brakeman: Prune obsolete warnings

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,25 +1,4 @@
 {
-  "ignored_warnings": [
-    {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 123,
-      "fingerprint": "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df",
-      "check_name": "EOLRuby",
-      "message": "Support for Ruby 2.7.6 ends on 2023-03-31",
-      "file": "Gemfile.lock",
-      "line": 316,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Weak",
-      "cwe_id": [
-        1104
-      ],
-      "note": ""
-    }
-  ],
-  "updated": "2023-01-31 11:13:02 +0000",
-  "brakeman_version": "5.4.0"
+  "ignored_warnings": [],
+  "brakeman_version": "7.0.0"
 }


### PR DESCRIPTION
This app hasn't been on Ruby 2.7 for a long time, so this olf warning can go.