### PR TITLE
Add comments to controls

### DIFF
--- a/app/controllers/controls_controller.rb
+++ b/app/controllers/controls_controller.rb
@@ -55,6 +55,7 @@ private
     params.expect(
       control: [
         :display_name,
+        :comment,
         :action_type,
         { action_attributes: %i[boost_factor filter_expression] },
       ],

--- a/app/models/control.rb
+++ b/app/models/control.rb
@@ -18,6 +18,7 @@ class Control < ApplicationRecord
   accepts_nested_attributes_for :action, update_only: true
 
   validates :display_name, presence: true
+  validates :comment, presence: true
 
   # Returns a representation of this Control as a Discovery Engine control resource
   def to_discovery_engine_control

--- a/app/views/controls/_form.html.erb
+++ b/app/views/controls/_form.html.erb
@@ -23,6 +23,16 @@
 
   <%= render "#{control.action.to_partial_path}_fields", action: control.action %>
 
+  <%= render "govuk_publishing_components/components/textarea", {
+    label: {
+      text: t_model_attr(:comment)
+    },
+    id: "control_comment",
+    name: "control[comment]",
+    value: control.comment,
+    error_items: error_items(control, :comment)
+  } %>
+
   <%= render "govuk_publishing_components/components/button", {
     text: t("common.buttons.save", model_name: t_model_name),
   } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,7 @@ en:
         other: external links
     attributes:
       control:
+        comment: Comment
         display_name: Name
         action: Action
         name: Google Cloud identifier

--- a/db/migrate/20250210143408_add_comment_to_controls.rb
+++ b/db/migrate/20250210143408_add_comment_to_controls.rb
@@ -1,0 +1,13 @@
+class AddCommentToControls < ActiveRecord::Migration[8.0]
+  def up
+    add_column :controls, :comment, :text,
+               comment: "A descriptive comment about why this control exists"
+
+    execute "UPDATE controls SET comment = '' WHERE comment IS NULL"
+    change_column_null :controls, :comment, false
+  end
+
+  def down
+    remove_column :controls, :comment
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_28_074343) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_10_143408) do
   create_table "control_boost_actions", charset: "utf8mb3", force: :cascade do |t|
     t.string "filter_expression", null: false
     t.float "boost_factor", null: false
@@ -31,6 +31,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_28_074343) do
     t.string "display_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "comment", null: false, comment: "A descriptive comment about why this control exists"
     t.index ["action_type", "action_id"], name: "index_controls_on_action_type_and_action_id", unique: true
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
 
   factory :control, traits: %i[remote_synchronizable] do
     display_name { "Control" }
+    comment { "This is a nice control." }
 
     action factory: :control_boost_action
 

--- a/spec/models/control_spec.rb
+++ b/spec/models/control_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe Control, type: :model do
       end
     end
 
+    context "without a comment" do
+      before do
+        control.comment = nil
+      end
+
+      it "is invalid" do
+        expect(control).to be_invalid
+        expect(control.errors).to be_of_kind(:comment, :blank)
+      end
+    end
+
     context "without an action" do
       before do
         control.action = nil

--- a/spec/system/controls_spec.rb
+++ b/spec/system/controls_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe "Controls", type: :system do
     fill_in "Name", with: "My boost control"
     fill_in "Filter expression", with: "is_cool = 1"
     fill_in "Boost factor", with: "0.42"
+    fill_in "Comment", with: "This is going to be great."
 
     click_button "Save control"
   end
@@ -89,6 +90,7 @@ RSpec.describe "Controls", type: :system do
   def and_i_submit_the_form_with_filter_control_details
     fill_in "Name", with: "My filter control"
     fill_in "Filter expression", with: "is_cool = 1"
+    fill_in "Comment", with: "This is going to be great."
 
     click_button "Save control"
   end
@@ -118,6 +120,7 @@ RSpec.describe "Controls", type: :system do
     fill_in "Name", with: "My updated boost control"
     fill_in "Filter expression", with: "is_really_cool = 999"
     fill_in "Boost factor", with: "0.999"
+    fill_in "Comment", with: "Now with 999 more BOOST!"
 
     click_button "Save control"
   end
@@ -125,6 +128,7 @@ RSpec.describe "Controls", type: :system do
   def and_i_submit_the_form_with_updated_filter_control_details
     fill_in "Name", with: "My updated filter control"
     fill_in "Filter expression", with: "is_really_cool = 999"
+    fill_in "Comment", with: "Now with 999 more FILTER!"
 
     click_button "Save control"
   end


### PR DESCRIPTION
This adds a `comment` field to controls, analogous to recommended links, allowing users to explain the purpose of a control.