### PR TITLE
Sync new controls after create

### DIFF
--- a/app/models/concerns/remote_synchronizable.rb
+++ b/app/models/concerns/remote_synchronizable.rb
@@ -23,7 +23,11 @@ module RemoteSynchronizable
     # Normally we would avoid using ActiveRecord callbacks to make network calls, but as the core
     # purpose of Search Admin is to provide an interface to manage resources on various remote APIs,
     # this is part of its core domain.
-    before_create :create_remote, unless: :skip_remote_synchronization_on_create
+    #
+    # Note the remote creation needs to be _after_ the record is created, as the record needs to
+    # have an ID. This won't persist if the remote creation fails as the transaction would be rolled
+    # back.
+    after_create :create_remote, unless: :skip_remote_synchronization_on_create
     before_update :update_remote
     before_destroy :destroy_remote
 

--- a/spec/support/shared_examples/concerns/remote_synchronizable.rb
+++ b/spec/support/shared_examples/concerns/remote_synchronizable.rb
@@ -17,6 +17,12 @@ RSpec.shared_examples "RemoteSynchronizable" do |client_class|
       expect(client).to have_received(:create).with(record)
     end
 
+    it "persists the record before passing it to the client" do
+      expect(client).to receive(:create).with(an_object_satisfying(&:persisted?))
+
+      record.save # rubocop:disable Rails/SaveBang (we're not interested in the return value)
+    end
+
     context "when the remote resource creation fails" do
       let(:error) { ClientError.new("Uh oh") }
 


### PR DESCRIPTION
We were accidentally syncing these _before_ the record was persisted, causing the ID to be nil at the point the remote ID was generated - so they would up with remote IDs like `search-admin-` instead of `search-admin-1234`.