### PR TITLE
Return to non-callback based synchronisation

### DIFF
--- a/app/controllers/controls_controller.rb
+++ b/app/controllers/controls_controller.rb
@@ -16,7 +16,7 @@ class ControlsController < ApplicationController
   def create
     @control = Control.new(control_params)
 
-    if @control.save
+    if @control.save_and_sync
       redirect_to @control, notice: t(".success")
     else
       render :new, status: :unprocessable_entity
@@ -30,7 +30,7 @@ class ControlsController < ApplicationController
   def update
     @control.assign_attributes(control_params.except(:action_type))
 
-    if @control.save
+    if @control.save_and_sync
       redirect_to @control, notice: t(".success")
     else
       render :edit, status: :unprocessable_entity
@@ -38,7 +38,7 @@ class ControlsController < ApplicationController
   end
 
   def destroy
-    if @control.destroy
+    if @control.destroy_and_sync
       redirect_to controls_path, notice: t(".success")
     else
       redirect_to @control, alert: t(".failure")

--- a/app/models/control.rb
+++ b/app/models/control.rb
@@ -11,8 +11,9 @@
 # https://cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1/latest/Google-Cloud-DiscoveryEngine-V1-Control
 class Control < ApplicationRecord
   include DiscoveryEngineNameable
+
   include RemoteSynchronizable
-  remote_synchronize with: DiscoveryEngine::ControlClient
+  self.remote_synchronizable_client_class = DiscoveryEngine::ControlClient
 
   delegated_type :action, types: %w[Control::BoostAction Control::FilterAction], dependent: :destroy
   accepts_nested_attributes_for :action, update_only: true

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,22 +1,5 @@
 FactoryBot.define do
-  # Unlike fixtures, record instances created through FactoryBot go through the full Rails callback
-  # lifecycle on creation. That is often desirable, but not in the case of our models using the
-  # `RemoteSynchronizable` concern to create counterparts on remote APIs automatically whenever you
-  # create a new record.
-  #
-  # This trait sets the `skip_remote_synchronization_on_create` flag to true on records created
-  # through factories that include it, so that this behaviour is skipped.
-  #
-  # If you _do_ want to specifically test remote synchronization on a record, you can override this
-  # manually when you build your model using `FactoryBot.build`:
-  # ```ruby
-  # build(:my_model, skip_remote_synchronization_on_create: false)
-  # ```
-  trait :remote_synchronizable do
-    skip_remote_synchronization_on_create { true }
-  end
-
-  factory :control, traits: %i[remote_synchronizable] do
+  factory :control do
     display_name { "Control" }
     comment { "This is a nice control." }
 

--- a/spec/support/shared_examples/concerns/remote_synchronizable.rb
+++ b/spec/support/shared_examples/concerns/remote_synchronizable.rb
@@ -8,57 +8,59 @@ RSpec.shared_examples "RemoteSynchronizable" do |client_class|
     allow(client_class).to receive(:new).and_return(client)
   end
 
-  describe "when creating a new record" do
-    subject(:record) { build(factory, skip_remote_synchronization_on_create: false) }
+  describe "#save_and_sync" do
+    describe "when creating a new record" do
+      subject(:record) { build(factory) }
 
-    it "creates the remote resource using the client" do
-      record.save!
+      it "creates the remote resource using the client" do
+        record.save_and_sync
 
-      expect(client).to have_received(:create).with(record)
-    end
-
-    it "persists the record before passing it to the client" do
-      expect(client).to receive(:create).with(an_object_satisfying(&:persisted?))
-
-      record.save # rubocop:disable Rails/SaveBang (we're not interested in the return value)
-    end
-
-    context "when the remote resource creation fails" do
-      let(:error) { ClientError.new("Uh oh") }
-
-      before do
-        allow(client).to receive(:create).and_raise(error)
-
-        record.save # rubocop:disable Rails/SaveBang (we're checking record state)
+        expect(client).to have_received(:create).with(record)
       end
 
-      it "stops the record from being created" do
-        expect(record).not_to be_persisted
-      end
-    end
-  end
+      it "persists the record before passing it to the client" do
+        expect(client).to receive(:create).with(an_object_satisfying(&:persisted?))
 
-  describe "when updating an existing record" do
-    subject(:record) { create(factory) }
-
-    it "updates the remote resource" do
-      record.save!
-
-      expect(client).to have_received(:update).with(record)
-    end
-
-    context "when the remote resource update fails" do
-      let(:error) { ClientError.new("Uh oh") }
-
-      before do
-        allow(client).to receive(:update).and_raise(error)
-
-        record.updated_at = Time.current # change something so we can check it won't save
-        record.save # rubocop:disable Rails/SaveBang (we're checking record state)
+        record.save_and_sync
       end
 
-      it "stops the record from being persisted" do
-        expect(record).to be_changed
+      context "when the remote resource creation fails" do
+        let(:error) { ClientError.new("Uh oh") }
+
+        before do
+          allow(client).to receive(:create).and_raise(error)
+
+          record.save_and_sync
+        end
+
+        it "stops the record from being created" do
+          expect(record).not_to be_persisted
+        end
+      end
+    end
+
+    describe "when updating an existing record" do
+      subject(:record) { create(factory) }
+
+      it "updates the remote resource" do
+        record.save_and_sync
+
+        expect(client).to have_received(:update).with(record)
+      end
+
+      context "when the remote resource update fails" do
+        let(:error) { ClientError.new("Uh oh") }
+
+        before do
+          allow(client).to receive(:update).and_raise(error)
+
+          record.updated_at = Time.current # change something so we can check it won't save
+          record.save_and_sync
+        end
+
+        it "stops the record from being persisted" do
+          expect(record).to be_changed
+        end
       end
     end
   end
@@ -67,7 +69,7 @@ RSpec.shared_examples "RemoteSynchronizable" do |client_class|
     subject(:record) { create(factory) }
 
     it "deletes the remote resource" do
-      record.destroy!
+      record.destroy_and_sync
 
       expect(client).to have_received(:delete).with(record)
     end
@@ -78,7 +80,7 @@ RSpec.shared_examples "RemoteSynchronizable" do |client_class|
       before do
         allow(client).to receive(:delete).and_raise(error)
 
-        record.destroy # rubocop:disable Rails/SaveBang (we're checking record state)
+        record.destroy_and_sync
       end
 
       it "stops the record from being destroyed" do

--- a/spec/system/controls_spec.rb
+++ b/spec/system/controls_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe "Controls", type: :system do
-  let(:control) do
+  let(:control_client) do
     instance_double(DiscoveryEngine::ControlClient, create: true, update: true, delete: true)
   end
 
   before do
-    allow(DiscoveryEngine::ControlClient).to receive(:new).and_return(control)
+    allow(DiscoveryEngine::ControlClient).to receive(:new).and_return(control_client)
   end
 
   scenario "Viewing controls" do
@@ -97,6 +97,7 @@ RSpec.describe "Controls", type: :system do
 
   def then_my_control_has_been_created
     expect(Control.count).to eq(1)
+    expect(control_client).to have_received(:create)
   end
 
   def and_i_can_see_the_boost_control_details
@@ -135,6 +136,7 @@ RSpec.describe "Controls", type: :system do
 
   def then_the_control_has_been_updated
     expect(page).to have_content("control was successfully updated")
+    expect(control_client).to have_received(:update)
   end
 
   def and_i_can_see_the_updated_boost_control_details
@@ -157,5 +159,6 @@ RSpec.describe "Controls", type: :system do
   def then_the_control_has_been_deleted
     expect(page).to have_content("control was successfully deleted")
     expect(Control.count).to eq(0)
+    expect(control_client).to have_received(:delete)
   end
 end


### PR DESCRIPTION
The implementation of another feature brought up the potential of callback order being significant, which isn't a problem per se but required clarifying comments and additional tests, and made me realise that relying on callbacks for this synchronisation behaviour might cause sustainability issues down the line especially once we add deferred synchronisation.

This reverts to the previous synchronisation design that defines and uses explicit `#sync`, `#save_and_sync`, and `#destroy_and_sync` methods from the `RemoteSynchronizable` concern.

- Revert to explicit design for `RemoteSynchronizable` concern and remove callbacks
- Move concern configuration from macro method to simpler class variable setting
- Amend system tests to include actual end-to-end tests of sync