### PR TITLE
Use summary card instead of list

### DIFF
--- a/app/views/controls/_boost_action.html.erb
+++ b/app/views/controls/_boost_action.html.erb
@@ -1,12 +1,12 @@
-<%= render "govuk_publishing_components/components/summary_list", {
+<%= render "govuk_publishing_components/components/summary_card", {
   title: t(".action_heading"),
-  items: [
+  rows: [
     {
-      field: t_model_attr(:filter_expression, on: boost_action),
+      key: t_model_attr(:filter_expression, on: boost_action),
       value: tag.code(boost_action.filter_expression),
     },
     {
-      field: t_model_attr(:boost_factor, on: boost_action),
+      key: t_model_attr(:boost_factor, on: boost_action),
       value: boost_action.boost_factor
     },
   ]

--- a/app/views/controls/_filter_action.html.erb
+++ b/app/views/controls/_filter_action.html.erb
@@ -1,8 +1,8 @@
-<%= render "govuk_publishing_components/components/summary_list", {
+<%= render "govuk_publishing_components/components/summary_card", {
   title: t(".action_heading"),
-  items: [
+  rows: [
     {
-      field: t_model_attr(:filter_expression, on: filter_action),
+      key: t_model_attr(:filter_expression, on: filter_action),
       value: tag.code(filter_action.filter_expression),
     },
   ]

--- a/app/views/controls/show.html.erb
+++ b/app/views/controls/show.html.erb
@@ -32,15 +32,15 @@
   ) %>
 </div>
 
-<%= render "govuk_publishing_components/components/summary_list", {
+<%= render "govuk_publishing_components/components/summary_card", {
   title: t(".control_heading"),
-  items: [
+  rows: [
     {
-      field: t_model_attr(:display_name),
+      key: t_model_attr(:display_name),
       value: @control.display_name,
     },
     {
-      field: t_model_attr(:name),
+      key: t_model_attr(:name),
       value: tag.code(@control.name),
     }
   ]

--- a/app/views/serving_configs/show.html.erb
+++ b/app/views/serving_configs/show.html.erb
@@ -26,26 +26,27 @@
   } %>
 </div>
 
-<%= render "govuk_publishing_components/components/summary_list", {
-  items: [
+<%= render "govuk_publishing_components/components/summary_card", {
+  title: t(".serving_config_heading"),
+  rows: [
     {
-      field: t_model_attr(:display_name),
+      key: t_model_attr(:display_name),
       value: @serving_config.display_name,
     },
     {
-      field: t_model_attr(:use_case),
+      key: t_model_attr(:use_case),
       value: serving_config_use_case_tag(@serving_config),
     },
     {
-      field: t_model_attr(:description),
+      key: t_model_attr(:description),
       value: @serving_config.description,
     },
     {
-      field: t_model_attr(:remote_resource_id),
+      key: t_model_attr(:remote_resource_id),
       value: tag.code(@serving_config.remote_resource_id),
     },
     {
-      field: t_model_attr(:name),
+      key: t_model_attr(:name),
       value: tag.code(@serving_config.name),
     }
   ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,5 +171,6 @@ en:
     index:
       page_title: Serving configs
     show:
+      serving_config_heading: Serving config details
       buttons:
         preview: Preview on GOV.UK


### PR DESCRIPTION
This changes our use of the `summary_list` component to the `summary_card` component instead, which is more suited to having several sections displayed on a single page.

## Screenshots
### Before
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/63c5dbc5-fc06-4e80-bf5c-a9f02cc4ff66" />

### After
<img width="999" alt="image" src="https://github.com/user-attachments/assets/dc9b8820-dc59-48af-92c5-076c22e09b3d" />
