### PR TITLE
Add missing `PUBLISHING_API_BEARER_TOKEN` to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN bootsnap precompile --gemfile .
 ENV SECRET_KEY_BASE=none
 ENV GOVUK_NOTIFY_API_KEY=none
 ENV DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME=none
+ENV PUBLISHING_API_BEARER_TOKEN=none
 RUN rails assets:precompile && rm -fr log
 
 


### PR DESCRIPTION
This is needed for Rails to be able to boot to precompile assets.