### PR TITLE
Update RemoteSynchronizable documentation

### DIFF
--- a/app/models/concerns/remote_synchronizable.rb
+++ b/app/models/concerns/remote_synchronizable.rb
@@ -1,11 +1,11 @@
-# Enhances a model with lifecycle callbacks to synchronise it with a remote resource using a client
+# Enhances a model with methods to synchronise it with a remote resource using a client
 # class (conventionally located in `app/clients/`).
 #
 # Example:
 # ```ruby
 # class Foo < ApplicationRecord
 #   include RemoteSynchronizable
-#   remote_synchronize with: BarApi::FooClient
+#   self.remote_synchronizable_client_class = BarApi::FooClient
 # end
 # ```
 #


### PR DESCRIPTION
This concern was reverted in d045d1d to the previous implementation where the
client is explicitly set as a class variable rather than by a method
call, but it looks like the documentation still reflects the previous
way.

Similarly, it no longer uses lifecycle callbacks but relies on these
methods to be explicitly called.
