### PR TITLE
Restrict editing of system serving config attachments

### DIFF
--- a/app/controllers/control_attachments_controller.rb
+++ b/app/controllers/control_attachments_controller.rb
@@ -24,7 +24,10 @@ private
   end
 
   def set_serving_config
-    @serving_config = ServingConfig.includes(:controls).find(params[:serving_config_id])
+    @serving_config = ServingConfig
+      .user_editable
+      .includes(:controls)
+      .find(params[:serving_config_id])
   end
 
   def control_ids_param

--- a/app/helpers/serving_configs_helper.rb
+++ b/app/helpers/serving_configs_helper.rb
@@ -25,4 +25,14 @@ module ServingConfigsHelper
       }
     end
   end
+
+  # Returns the summary card component attachment actions for the given serving config
+  def serving_config_attached_controls_actions(serving_config)
+    return [] unless serving_config.user_editable?
+
+    [{
+      label: t("serving_configs.show.buttons.edit_control_attachments"),
+      href: edit_serving_config_control_attachments_path(serving_config),
+    }]
+  end
 end

--- a/app/models/serving_config.rb
+++ b/app/models/serving_config.rb
@@ -7,6 +7,9 @@
 #
 # see https://cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1beta/latest/Google-Cloud-DiscoveryEngine-V1beta-ServingConfig
 class ServingConfig < ApplicationRecord
+  # Defines which use cases of serving configs can be edited by users through the UI
+  USER_EDITABLE_USE_CASES = %w[live preview].freeze
+
   include DiscoveryEngineNameable
 
   include RemoteSynchronizable
@@ -32,6 +35,16 @@ class ServingConfig < ApplicationRecord
 
   validates :display_name, presence: true
   validates :remote_resource_id, presence: true, uniqueness: true
+
+  # Returns all serving configs that can be edited by users through the UI
+  def self.user_editable
+    where(use_case: USER_EDITABLE_USE_CASES)
+  end
+
+  # Returns whether this serving config can be edited by users through the UI
+  def user_editable?
+    use_case.in?(USER_EDITABLE_USE_CASES)
+  end
 
   # A URL to preview this serving config on Finder Frontend
   def preview_url

--- a/app/views/serving_configs/show.html.erb
+++ b/app/views/serving_configs/show.html.erb
@@ -54,11 +54,6 @@
 
 <%= render "govuk_publishing_components/components/summary_card", {
   title: t(".attached_controls_heading"),
-  summary_card_actions: [
-    {
-      label: t(".buttons.edit_control_attachments"),
-      href: edit_serving_config_control_attachments_path(@serving_config),
-    }
-  ],
+  summary_card_actions: serving_config_attached_controls_actions(@serving_config),
   rows: serving_config_attached_controls_rows(@serving_config)
 } %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :control do
-    display_name { "Control" }
+    sequence(:display_name) { "Control #{it}" }
+
     comment { "This is a nice control." }
 
     action factory: :control_boost_action
@@ -31,10 +32,11 @@ FactoryBot.define do
   end
 
   factory :serving_config do
+    sequence(:display_name) { "Serving config #{it}" }
+    sequence(:remote_resource_id) { "serving-config-#{it}" }
+
     use_case { :live }
-    display_name { "Serving config" }
     description { "A serving configuration" }
-    remote_resource_id { "serving-config" }
   end
 
   factory :user do

--- a/spec/models/serving_config_spec.rb
+++ b/spec/models/serving_config_spec.rb
@@ -41,6 +41,38 @@ RSpec.describe ServingConfig, type: :model do
     end
   end
 
+  describe ".user_editable" do
+    let!(:live_serving_config) { create(:serving_config, use_case: :live) }
+    let!(:preview_serving_config) { create(:serving_config, use_case: :preview) }
+    let!(:system_serving_config) { create(:serving_config, use_case: :system) }
+
+    it "returns only live and preview serving configs" do
+      expect(described_class.user_editable).to contain_exactly(live_serving_config, preview_serving_config)
+    end
+  end
+
+  describe "#user_editable" do
+    subject(:serving_config) { build_stubbed(:serving_config, use_case:) }
+
+    context "when the use case is live" do
+      let(:use_case) { :live }
+
+      it { is_expected.to be_user_editable }
+    end
+
+    context "when the use case is preview" do
+      let(:use_case) { :preview }
+
+      it { is_expected.to be_user_editable }
+    end
+
+    context "when the use case is system" do
+      let(:use_case) { :system }
+
+      it { is_expected.not_to be_user_editable }
+    end
+  end
+
   describe "#remote_resource_id" do
     subject(:serving_config) { create(:serving_config, remote_resource_id: "hello") }
 

--- a/spec/requests/control_attachments_spec.rb
+++ b/spec/requests/control_attachments_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "Control attachments", type: :request do
+  include_context "with an SSO authenticated user"
+
+  describe "non-user editable serving configs" do
+    let(:serving_config) { create(:serving_config, use_case: :system) }
+
+    it "doesn't render the edit page" do
+      get edit_serving_config_control_attachments_path(serving_config)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "doesn't accept updates" do
+      put serving_config_control_attachments_path(serving_config), params: {
+        serving_config: { control_ids: create_list(:control, 2).map(&:id) },
+      }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
Our serving configs have different use cases, one of which is `system`. These are internal serving configs that we want don't want users to be able to attach controls or otherwise edit.

This adds a scope and predicate for the concept of `user_editable` serving configs, restricts the `ControlAttachmentsController` to only allow edit/update for editable serving configs, and removes the "Manage attached controls" link for those that aren't.