### PR TITLE
Add UI for autocomplete denylist management

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,12 +15,14 @@
 @import 'govuk_publishing_components/components/layout-footer';
 @import 'govuk_publishing_components/components/layout-for-admin';
 @import 'govuk_publishing_components/components/layout-header';
+@import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/search';
 @import 'govuk_publishing_components/components/secondary-navigation';
 @import 'govuk_publishing_components/components/skip-link';
 @import 'govuk_publishing_components/components/success-alert';
 @import 'govuk_publishing_components/components/summary-list';
 @import 'govuk_publishing_components/components/table';
+@import 'govuk_publishing_components/components/tabs';
 @import 'govuk_publishing_components/components/textarea';
 
 .actions {
@@ -38,4 +40,20 @@
 // Display filter expressions with less large font size
 .app-filter-expression {
   font-size: 16px;
+}
+
+.app-actions__count {
+  margin-top: govuk-spacing(1);
+  padding-right: govuk-spacing(2);
+  text-align: right;
+  @include govuk-font(16);
+  color: govuk-colour("dark-grey");
+}
+
+.app-denylist-entry-comment {
+  display: block;
+  margin-top: govuk-spacing(2);
+  @include govuk-font(16);
+  color: govuk-colour("dark-grey");
+  font-style: italic;
 }

--- a/app/controllers/completion_denylist_entries_controller.rb
+++ b/app/controllers/completion_denylist_entries_controller.rb
@@ -1,0 +1,64 @@
+class CompletionDenylistEntriesController < ApplicationController
+  before_action :set_completion_denylist_entry, only: %i[edit update destroy]
+
+  self.primary_navigation_area = :autocomplete
+  self.secondary_navigation_area = :completion_denylist_entries
+  layout "autocomplete"
+
+  def index
+    @completion_denylist_entries = CompletionDenylistEntry
+      .where(category: category_filter)
+      .order(:phrase)
+    @category_filter = category_filter
+    @total_count = CompletionDenylistEntry.count
+  end
+
+  def new
+    @completion_denylist_entry = CompletionDenylistEntry.new
+  end
+
+  def create
+    @completion_denylist_entry = CompletionDenylistEntry.new(completion_denylist_entry_params)
+
+    if @completion_denylist_entry.save
+      redirect_to completion_denylist_entries_path(category: @completion_denylist_entry.category), notice: t(".success")
+    else
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    @completion_denylist_entry.assign_attributes(completion_denylist_entry_params)
+
+    if @completion_denylist_entry.save
+      redirect_to completion_denylist_entries_path(category: @completion_denylist_entry.category), notice: t(".success")
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @completion_denylist_entry.destroy
+      redirect_to completion_denylist_entries_path(category: @completion_denylist_entry.category), notice: t(".success")
+    else
+      redirect_to completion_denylist_entries_path(category: @completion_denylist_entry.category), alert: t(".failure")
+    end
+  end
+
+private
+
+  def set_completion_denylist_entry
+    @completion_denylist_entry = CompletionDenylistEntry.find(params[:id])
+  end
+
+  def completion_denylist_entry_params
+    params.expect(completion_denylist_entry: %i[phrase comment match_type category])
+  end
+
+  def category_filter
+    CompletionDenylistEntry.categories.keys.find { it == params[:category] } ||
+      CompletionDenylistEntry.categories.keys.first
+  end
+end

--- a/app/controllers/completion_denylist_entry_imports_controller.rb
+++ b/app/controllers/completion_denylist_entry_imports_controller.rb
@@ -1,0 +1,28 @@
+class CompletionDenylistEntryImportsController < ApplicationController
+  self.primary_navigation_area = :autocomplete
+  self.secondary_navigation_area = :completion_denylist_entries
+  layout "autocomplete"
+
+  def new
+    @completion_denylist_entry_import = CompletionDenylistEntryImport.new
+  end
+
+  def create
+    @completion_denylist_entry_import = CompletionDenylistEntryImport.new(completion_denylist_entry_import_params)
+
+    if @completion_denylist_entry_import.save
+      redirect_to(
+        completion_denylist_entries_path(category: @completion_denylist_entry_import.category),
+        notice: t(".success", count: @completion_denylist_entry_import.records.size),
+      )
+    else
+      render :new
+    end
+  end
+
+private
+
+  def completion_denylist_entry_import_params
+    params.expect(completion_denylist_entry_import: %i[category denylist_csv_data])
+  end
+end

--- a/app/helpers/completion_denylist_entries_helper.rb
+++ b/app/helpers/completion_denylist_entries_helper.rb
@@ -1,0 +1,24 @@
+module CompletionDenylistEntriesHelper
+  # see https://design-system.service.gov.uk/components/tag#additional-colours
+  COMPLETION_DENYLIST_ENTRY_MATCH_TYPE_TAG_COLOURS = {
+    exact_match: "blue",
+    contains: "grey",
+  }.freeze
+
+  def completion_denylist_entry_phrase_with_visible_spaces(completion_denylist_entry)
+    completion_denylist_entry.phrase.gsub(/\s/, "⎵")
+  end
+
+  def completion_denylist_entry_match_type_tag(completion_denylist_entry)
+    scope = "activerecord.attributes.completion_denylist_entry.match_type_values"
+    colour = COMPLETION_DENYLIST_ENTRY_MATCH_TYPE_TAG_COLOURS[
+      completion_denylist_entry.match_type.to_sym
+    ]
+
+    tag.span(
+      t(completion_denylist_entry.match_type, scope:),
+      class: "govuk-tag govuk-tag--#{colour}",
+      title: t(completion_denylist_entry.match_type, scope: "hints.completion_denylist_entry_match_type"),
+    )
+  end
+end

--- a/app/models/completion_denylist_entry.rb
+++ b/app/models/completion_denylist_entry.rb
@@ -1,0 +1,30 @@
+class CompletionDenylistEntry < ApplicationRecord
+  # The maximum length of the phrase (API limit)
+  MAX_PHRASE_LENGTH = 125
+  # The maximum number of denylist entries permitted at any one time (API limit)
+  MAX_ENTRIES = 1000
+
+  enum :category, {
+    general: 0,
+    names: 1,
+    offensive: 2,
+  }, validate: true
+
+  enum :match_type, {
+    # see https://cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1/latest/Google-Cloud-DiscoveryEngine-V1-SuggestionDenyListEntry-MatchOperator
+    exact_match: 0,
+    contains: 1,
+  }, validate: true
+
+  validates :phrase, presence: true, length: { maximum: MAX_PHRASE_LENGTH }, uniqueness: true
+  normalizes :phrase, with: ->(phrase) { phrase.downcase }
+  validate :does_not_exceed_maximum_entries
+
+private
+
+  def does_not_exceed_maximum_entries
+    return if CompletionDenylistEntry.count < MAX_ENTRIES
+
+    errors.add(:base, :too_many_entries, max_entries: MAX_ENTRIES)
+  end
+end

--- a/app/models/completion_denylist_entry_import.rb
+++ b/app/models/completion_denylist_entry_import.rb
@@ -1,0 +1,92 @@
+# Parses and creates records for denylist entries from CSV-formatted input data, which can be either
+# tab-separated (usually copy/pasted from Google Sheets) or comma-separated (from a CSV file or
+# manual user input).
+#
+# At a minimum, each row must contain a phrase. It can also optionally contain a match type (assumed
+# to be the default match type if empty) and a comment.
+#
+# The import is all-or-nothing: if any row in the input data or any of the records are invalid, the
+# import will fail and no records will be created.
+class CompletionDenylistEntryImport
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  extend ActiveModel::Translation
+
+  attr_accessor :category, :denylist_csv_data
+
+  validates :category, inclusion: { in: CompletionDenylistEntry.categories.keys }
+  validates :denylist_csv_data, presence: true
+  validate :sense_check_parsed_data, :validate_individual_records, :validate_total_count
+
+  def save
+    return false unless valid?
+
+    # The records are valid at this point. This _would_ fail if several users were to ever try to
+    # manage conflicting denylist entries at the same time, but that's so unlikely we'll just accept
+    # that this could raise.
+    records.each(&:save!)
+    records
+  end
+
+  def records
+    @records ||= parsed_data.map do |row|
+      CompletionDenylistEntry.new(
+        phrase: row[0],
+        match_type: row[1]&.downcase || CompletionDenylistEntry.match_types.keys.first,
+        comment: row[2].presence,
+        category:,
+      )
+    end
+  end
+
+private
+
+  def parsed_data
+    @parsed_data ||= CSV.parse(denylist_csv_data, col_sep:).reject(&:blank?)
+  end
+
+  def col_sep
+    # Assume that if the data contains a tab character (for example from being copied from Google
+    # Sheets), it's tab-separated.
+    return "\t" if denylist_csv_data.include?("\t")
+
+    ","
+  end
+
+  def sense_check_parsed_data
+    parsed_data.each do |row|
+      unless row.size.in?(1..3)
+        errors.add(:denylist_csv_data, :entry_invalid, phrase: row.join(","), reason: "has an unexpected number of columns")
+
+        next
+      end
+
+      next if row[0].present?
+
+      errors.add(:denylist_csv_data, :entry_invalid, phrase: row.join(","), reason: "does not contain a phrase")
+    end
+  end
+
+  def validate_individual_records
+    # Don't bother validating the records if the parsed data is already invalid
+    return if errors.any?
+
+    records.each do |record|
+      next if record.valid?
+
+      record.errors.full_messages.each do |reason|
+        errors.add(:denylist_csv_data, :entry_invalid, phrase: record.phrase, reason:)
+      end
+    end
+  end
+
+  def validate_total_count
+    return if CompletionDenylistEntry.count + records.size <= CompletionDenylistEntry::MAX_ENTRIES
+
+    errors.add(
+      :denylist_csv_data,
+      :would_exceed_max_entries,
+      count: CompletionDenylistEntry::MAX_ENTRIES,
+    )
+  end
+end

--- a/app/views/completion_denylist_entries/_form.html.erb
+++ b/app/views/completion_denylist_entries/_form.html.erb
@@ -1,0 +1,66 @@
+<%= form_with(model: completion_denylist_entry) do |f| %>
+  <% if completion_denylist_entry.errors.any? %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      id: "error-summary",
+      title: t("common.error_summary.title"),
+      description: t("common.error_summary.description", model_name: t_model_name),
+      items: error_summary_items(completion_denylist_entry)
+    } %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t_model_attr(:phrase)
+    },
+    id: "completion_denylist_entry_phrase",
+    name: "completion_denylist_entry[phrase]",
+    value: completion_denylist_entry.phrase,
+    hint: t("hints.completion_denylist_entry_phrase"),
+    error_items: error_items(completion_denylist_entry, :phrase)
+  } %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t_model_attr(:comment)
+    },
+    id: "completion_denylist_entry_comment",
+    name: "completion_denylist_entry[comment]",
+    value: completion_denylist_entry.comment,
+    hint: t("hints.completion_denylist_entry_comment"),
+    error_items: error_items(completion_denylist_entry, :comment)
+  } %>
+
+  <%= render "govuk_publishing_components/components/radio", {
+    heading: t_model_attr(:match_type),
+    name: "completion_denylist_entry[match_type]",
+    small: true,
+    items: CompletionDenylistEntry.match_types.map do |match_type, _|
+      {
+        text: t(match_type, scope: "activerecord.attributes.completion_denylist_entry.match_type_values"),
+        hint_text: t(match_type, scope: "hints.completion_denylist_entry_match_type"),
+        value: match_type,
+        checked: completion_denylist_entry.match_type == match_type,
+      }
+    end,
+    error_items: error_items(completion_denylist_entry, :match_type)
+  } %>
+
+  <%= render "govuk_publishing_components/components/radio", {
+    heading: t_model_attr(:category),
+    name: "completion_denylist_entry[category]",
+    small: true,
+    hint: t("hints.completion_denylist_entry_category"),
+    items: CompletionDenylistEntry.categories.map do |category, _|
+      {
+        text: t(category, scope: "activerecord.attributes.completion_denylist_entry.category_values"),
+        value: category,
+        checked: completion_denylist_entry.category == category,
+      }
+    end,
+    error_items: error_items(completion_denylist_entry, :category)
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("common.buttons.save", model_name: t_model_name),
+  } %>
+<% end %>

--- a/app/views/completion_denylist_entries/edit.html.erb
+++ b/app/views/completion_denylist_entries/edit.html.erb
@@ -1,0 +1,25 @@
+<% content_for(:breadcrumbs) do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: t("completion_denylist_entries.index.page_title"),
+        url: completion_denylist_entries_path
+      },
+      {
+        title: t(".page_title", phrase: @completion_denylist_entry.phrase_was),
+      }
+    ]
+  } %>
+<% end %>
+
+<%= render "page_title", title: @completion_denylist_entry.phrase_was %>
+
+<div class="actions">
+  <%= delete_button(
+    t("common.buttons.delete", model_name: t_model_name),
+    completion_denylist_entry_path(@completion_denylist_entry),
+    is_inline: true
+  ) %>
+</div>
+
+<%= render 'form', completion_denylist_entry: @completion_denylist_entry %>

--- a/app/views/completion_denylist_entries/index.html.erb
+++ b/app/views/completion_denylist_entries/index.html.erb
@@ -5,6 +5,12 @@
 
   <div class="govuk-grid-column-one-third app-actions__count">
     <%= render "govuk_publishing_components/components/button", {
+      text: t(".buttons.import"),
+      href: new_completion_denylist_entry_import_path,
+      inline_layout: true,
+      secondary: true,
+    } %>
+    <%= render "govuk_publishing_components/components/button", {
       text: t("common.buttons.new", model_name: t_model_name),
       href: new_completion_denylist_entry_path,
       inline_layout: true

--- a/app/views/completion_denylist_entries/index.html.erb
+++ b/app/views/completion_denylist_entries/index.html.erb
@@ -1,0 +1,56 @@
+<div class="govuk-grid-row actions">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "page_title", title: t(".page_title") %>
+  </div>
+
+  <div class="govuk-grid-column-one-third app-actions__count">
+    <%= render "govuk_publishing_components/components/button", {
+      text: t("common.buttons.new", model_name: t_model_name),
+      href: new_completion_denylist_entry_path,
+      inline_layout: true
+    } %>
+    <div class="app-actions__count">
+      Currently using <%= pluralize(number_with_delimiter(@total_count), "entry") %> out of a
+      maximum of <%= number_with_delimiter(CompletionDenylistEntry::MAX_ENTRIES) %>
+    </div>
+  </div>
+</div>
+
+<%= render "govuk_publishing_components/components/tabs", {
+  as_links: true,
+  tabs: CompletionDenylistEntry.categories.map do |category, _|
+    {
+      href: completion_denylist_entries_path(category: category),
+      label: t(category, scope: "activerecord.attributes.completion_denylist_entry.category_values"),
+      active: @category_filter == category
+    }
+  end,
+} %>
+
+<div class="govuk-!-margin-top-6 app-table__container" data-module="filterable-table">
+  <%= render "govuk_publishing_components/components/table", {
+    filterable: @completion_denylist_entries.any?,
+    label: t(".filter_table_label"),
+    head: [
+      { text: t_model_attr(:phrase) },
+      { text: t_model_attr(:match_type) },
+      { text: t_model_attr(:updated_at) },
+    ],
+    rows: @completion_denylist_entries.map do |completion_denylist_entry|
+      [
+        { text: capture do
+          concat link_to(
+            completion_denylist_entry_phrase_with_visible_spaces(completion_denylist_entry),
+            edit_completion_denylist_entry_path(completion_denylist_entry),
+            class: "govuk-link",
+          )
+          if completion_denylist_entry.comment?
+            concat tag.span(completion_denylist_entry.comment, class: "app-denylist-entry-comment")
+          end
+        end },
+        { text: completion_denylist_entry_match_type_tag(completion_denylist_entry) },
+        { text: completion_denylist_entry.updated_at.to_fs(:govuk) },
+      ]
+    end
+  } %>
+</div>

--- a/app/views/completion_denylist_entries/new.html.erb
+++ b/app/views/completion_denylist_entries/new.html.erb
@@ -1,0 +1,17 @@
+<% content_for(:breadcrumbs) do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: t("completion_denylist_entries.index.page_title"),
+        url: completion_denylist_entries_path
+      },
+      {
+        title: t(".page_title"),
+      }
+    ]
+  } %>
+<% end %>
+
+<%= render "page_title", title: t(".page_title") %>
+
+<%= render "form", completion_denylist_entry: @completion_denylist_entry %>

--- a/app/views/completion_denylist_entry_imports/new.html.erb
+++ b/app/views/completion_denylist_entry_imports/new.html.erb
@@ -1,0 +1,59 @@
+<% content_for(:breadcrumbs) do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: t("completion_denylist_entries.index.page_title"),
+        url: completion_denylist_entries_path
+      },
+      {
+        title: t(".page_title"),
+      }
+    ]
+  } %>
+<% end %>
+
+<%= render "page_title", title: t(".page_title") %>
+
+<%= form_with(model: @completion_denylist_entry_import) do |f| %>
+  <% if @completion_denylist_entry_import.errors.any? %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      id: "error-summary",
+      title: t("common.error_summary.title"),
+      description: t("common.error_summary.description", model_name: t_model_name),
+      items: error_summary_items(@completion_denylist_entry_import)
+    } %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/radio", {
+    id: "completion_denylist_entry_import_category",
+    heading: t_model_attr(:category),
+    name: "completion_denylist_entry_import[category]",
+    small: true,
+    hint: t("hints.completion_denylist_entry_category"),
+    items: CompletionDenylistEntry.categories.map do |category, _|
+      {
+        text: t(category, scope: "activerecord.attributes.completion_denylist_entry.category_values"),
+        value: category,
+        checked: @completion_denylist_entry_import.category == category,
+      }
+    end,
+    error_items: error_items(@completion_denylist_entry_import, :category)
+  } %>
+
+  <%= render "govuk_publishing_components/components/textarea", {
+    id: "completion_denylist_entry_import_denylist_csv_data",
+    rows: 10,
+    label: {
+      heading_size: "m",
+      text: t_model_attr(:denylist_csv_data)
+    },
+    hint: t("hints.completion_denylist_entry_import_denylist_csv_data_html"),
+    error_items: error_items(@completion_denylist_entry_import, :denylist_csv_data),
+    name: "completion_denylist_entry_import[denylist_csv_data]",
+    value: @completion_denylist_entry_import.denylist_csv_data,
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: t(".buttons.import"),
+  } %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,11 @@
         active: primary_navigation_area == :search,
       },
       {
+        text: t("primary_navigation_areas.autocomplete"),
+        href: completion_denylist_entries_path,
+        active: primary_navigation_area == :autocomplete,
+      },
+      {
         text: Current.user.name,
         href: Plek.new.external_url_for("signon"),
       },

--- a/app/views/layouts/autocomplete.html.erb
+++ b/app/views/layouts/autocomplete.html.erb
@@ -1,0 +1,14 @@
+<% content_for :secondary_nav do %>
+  <%= render "govuk_publishing_components/components/secondary_navigation", {
+    aria_label: "Search secondary navigation",
+    items: [
+      {
+        label: t("completion_denylist_entries.index.page_title"),
+        href: completion_denylist_entries_path,
+        current: secondary_navigation_area == :completion_denylist_entries,
+      },
+    ]
+  } %>
+<% end %>
+
+<%= render template: "layouts/application" %>

--- a/config/initializers/govuk_date_formats.rb
+++ b/config/initializers/govuk_date_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:govuk] = "%-d %B %Y"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,7 @@ en:
 
   primary_navigation_areas:
     search: Search
+    autocomplete: Autocomplete
 
   attributes:
     created_at: Created at
@@ -64,6 +65,19 @@ en:
       target="_blank" class="govuk-link">Google documentation</a> for syntax and more information.
     attached_controls: |
       Select all controls that should be attached to this serving configuration.
+    completion_denylist_entry_phrase: >
+      The word or phrase to be blocked from autocomplete suggestions.
+    completion_denylist_entry_comment: >
+      A brief comment describing why this denylist entry is needed (if it isn't obvious)
+    completion_denylist_entry_match_type:
+      exact_match: >
+        "example" matches suggestion "example" only
+      contains: >
+        "example" matches suggestions "example", "an example", "some example text", "example.com",
+        "examples", ...
+    completion_denylist_entry_category: >
+      Helps organise denylist entries in Search Admin. This has no effect on the search engine.
+
 
   activerecord:
     models:
@@ -79,6 +93,9 @@ en:
       control_attachment:
         one: attached control
         other: attached controls
+      completion_denylist_entry:
+        one: denylist entry
+        other: denylist entries
       recommended_link:
         one: external link
         other: external links
@@ -100,6 +117,19 @@ en:
         filter_expression: Filter expression
       control/filter_action:
         filter_expression: Filter expression
+      completion_denylist_entry:
+        phrase: Phrase
+        comment: Comment
+        category: Category
+        category_values:
+          general: General
+          names: Names
+          offensive: Offensive
+        match_type: Match type
+        match_type_values:
+          exact_match: Exact match
+          contains: Contains
+        updated_at: Last modified
       recommended_link:
         link: Link
         title: Title
@@ -165,6 +195,25 @@ en:
       page_title: Manage attached controls
     update:
       success: The attached controls for this serving configuration were successfully updated.
+
+  completion_denylist_entries:
+    index:
+      page_title: Denylist
+      filter_table_label: Filter denylist entries
+      buttons:
+        edit: Edit
+        delete: Delete
+    new:
+      page_title: New denylist entry
+    create:
+      success: The denylist entry was successfully created.
+    edit:
+      page_title: Edit %{phrase}
+    update:
+      success: The denylist entry was successfully updated.
+    destroy:
+      success: The denylist entry was successfully deleted.
+      failure: The denylist entry could not be deleted.
 
   recommended_links:
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,7 +77,37 @@ en:
         "examples", ...
     completion_denylist_entry_category: >
       Helps organise denylist entries in Search Admin. This has no effect on the search engine.
+    completion_denylist_entry_import_denylist_csv_data_html: |
+      <p>One line per new denylist entry as 1-3 column comma separated values in the following format:</p>
+      <code>phrase[,match_type[,comment]]</code>
+      <p>For example:</p>
+      <ul>
+        <li><code>foo</code></li>
+        <li><code>foo,exact_match</code></li>
+        <li><code>foo,contains,This is a comment</code></li>
+        <li><code>foo,,I don't have a match type - only a comment</code></li>
+      </ul>
+      <p>The tab character can be used as a separator (for example, for data copied from a spreadsheet), but if used for any entry, it must be used for all entries. The match type is optional and defaults to exact_match. You can use commas in the comment but you need to "quote" it as you would in a CSV file.</p>
 
+  activemodel:
+    models:
+      completion_denylist_entry_import:
+        one: denylist entry import
+        other: denylist entry imports
+    attributes:
+      completion_denylist_entry_import:
+        category: Category
+        denylist_csv_data: Denylist entries
+    errors:
+      models:
+        completion_denylist_entry_import:
+          attributes:
+            category:
+              inclusion: must be one of the available options
+            denylist_csv_data:
+              blank: must have at least one entry
+              would_exceed_max_entries: would exceed the maximum number of entries (%{count})
+              entry_invalid: contains invalid entry '%{phrase}' (%{reason})
 
   activerecord:
     models:
@@ -201,6 +231,7 @@ en:
       page_title: Denylist
       filter_table_label: Filter denylist entries
       buttons:
+        import: Import
         edit: Edit
         delete: Delete
     new:
@@ -214,6 +245,14 @@ en:
     destroy:
       success: The denylist entry was successfully deleted.
       failure: The denylist entry could not be deleted.
+
+  completion_denylist_entry_imports:
+    new:
+      page_title: Import denylist entries
+      buttons:
+        import: Import
+    create:
+      success: "%{count} denylist entries were successfully imported."
 
   recommended_links:
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,11 @@ en:
       messages:
         remote_error: |
           There was an error saving this record remotely: %{error_message}
+      models:
+        completion_denylist_entry:
+          too_many_entries: >
+            Vertex AI Search maximum denylist entry limit reached. You can only have
+            %{max_entries}.
 
   controls:
     index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     resource :control_attachments, only: %i[edit update]
   end
 
+  resources :completion_denylist_entries, except: %i[show]
   resources :recommended_links, path: "/recommended-links"
 
   root "recommended_links#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   end
 
   resources :completion_denylist_entries, except: %i[show]
+  resources :completion_denylist_entry_imports, only: %i[new create]
+
   resources :recommended_links, path: "/recommended-links"
 
   root "recommended_links#index"

--- a/db/migrate/20250408102814_create_completion_denylist_entries.rb
+++ b/db/migrate/20250408102814_create_completion_denylist_entries.rb
@@ -1,0 +1,15 @@
+class CreateCompletionDenylistEntries < ActiveRecord::Migration[8.0]
+  def change
+    create_table :completion_denylist_entries do |t|
+      t.string :phrase, null: false
+      t.integer :match_type, null: false, default: 0
+      t.integer :category, null: false, default: 0
+      t.string :comment
+
+      t.index :category
+      t.index :phrase, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_18_142926) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_08_102814) do
+  create_table "completion_denylist_entries", charset: "utf8mb3", force: :cascade do |t|
+    t.string "phrase", null: false
+    t.integer "match_type", default: 0, null: false
+    t.integer "category", default: 0, null: false
+    t.string "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category"], name: "index_completion_denylist_entries_on_category"
+    t.index ["phrase"], name: "index_completion_denylist_entries_on_phrase", unique: true
+  end
+
   create_table "control_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "control_id", null: false
     t.bigint "serving_config_id", null: false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -23,6 +23,13 @@ FactoryBot.define do
     filter_expression { 'link: ANY("/example")' }
   end
 
+  factory :completion_denylist_entry do
+    phrase { "tea time" }
+    match_type { :contains }
+    category { :general }
+    comment { "The tea time alarm has been suspended until further notice" }
+  end
+
   factory :recommended_link do
     title { "Tax online" }
     link { "https://www.tax.service.gov.uk/" }

--- a/spec/models/completion_denylist_entry_spec.rb
+++ b/spec/models/completion_denylist_entry_spec.rb
@@ -1,0 +1,111 @@
+RSpec.describe CompletionDenylistEntry, type: :model do
+  subject(:completion_denylist_entry) { build(:completion_denylist_entry) }
+
+  describe "normalizations" do
+    context "for the phrase" do
+      subject(:completion_denylist_entry) { build(:completion_denylist_entry, phrase: " TEA time") }
+
+      it "normalizes the phrase" do
+        completion_denylist_entry.save!
+        # Note whitespace is intentionally not trimmed to allow for "phrase" matching
+        expect(completion_denylist_entry.phrase).to eq(" tea time")
+      end
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to be_valid }
+
+    context "without a phrase" do
+      before do
+        completion_denylist_entry.phrase = nil
+      end
+
+      it "is not valid" do
+        expect(completion_denylist_entry).not_to be_valid
+        expect(completion_denylist_entry.errors).to be_of_kind(:phrase, :blank)
+      end
+    end
+
+    context "with a phrase longer than 125 characters" do
+      before do
+        completion_denylist_entry.phrase = "a" * 126
+      end
+
+      it "is not valid" do
+        expect(completion_denylist_entry).not_to be_valid
+        expect(completion_denylist_entry.errors).to be_of_kind(:phrase, :too_long)
+      end
+    end
+
+    context "with a duplicate phrase" do
+      let!(:other_entry) { create(:completion_denylist_entry, phrase: "duplicate") }
+
+      before do
+        completion_denylist_entry.phrase = "duplicate"
+      end
+
+      it "is not valid" do
+        expect(completion_denylist_entry).not_to be_valid
+        expect(completion_denylist_entry.errors).to be_of_kind(:phrase, :taken)
+      end
+    end
+
+    context "without a match_type" do
+      before do
+        completion_denylist_entry.match_type = nil
+      end
+
+      it "is not valid" do
+        expect(completion_denylist_entry).not_to be_valid
+        expect(completion_denylist_entry.errors).to be_of_kind(:match_type, :inclusion)
+      end
+    end
+
+    context "with an invalid match_type" do
+      before do
+        completion_denylist_entry.match_type = "invalid"
+      end
+
+      it "is not valid" do
+        expect(completion_denylist_entry).not_to be_valid
+        expect(completion_denylist_entry.errors).to be_of_kind(:match_type, :inclusion)
+      end
+    end
+
+    context "without a category" do
+      before do
+        completion_denylist_entry.category = nil
+      end
+
+      it "is not valid" do
+        expect(completion_denylist_entry).not_to be_valid
+        expect(completion_denylist_entry.errors).to be_of_kind(:category, :inclusion)
+      end
+    end
+
+    context "with an invalid category" do
+      before do
+        completion_denylist_entry.category = "invalid"
+      end
+
+      it "is not valid" do
+        expect(completion_denylist_entry).not_to be_valid
+        expect(completion_denylist_entry.errors).to be_of_kind(:category, :inclusion)
+      end
+    end
+
+    context "when the maximum number of entries has been exceeded" do
+      let!(:existing_entry) { create(:completion_denylist_entry, phrase: "i'm all you need") }
+
+      before do
+        stub_const("CompletionDenylistEntry::MAX_ENTRIES", 1)
+      end
+
+      it "is not valid" do
+        expect(completion_denylist_entry).not_to be_valid
+        expect(completion_denylist_entry.errors).to be_of_kind(:base, :too_many_entries)
+      end
+    end
+  end
+end

--- a/spec/models/denylist_entry_import_spec.rb
+++ b/spec/models/denylist_entry_import_spec.rb
@@ -1,0 +1,122 @@
+RSpec.describe CompletionDenylistEntryImport do
+  subject(:import) { described_class.new(category:, denylist_csv_data:) }
+  let(:category) { "offensive" }
+
+  describe "#save" do
+    context "with tab-delimited input" do
+      let(:denylist_csv_data) do
+        [
+          " foo\texact_match\tI don't like this word",
+          "bar \tcontains\tI like this word even less",
+          "baz\tCONTAINS\tDon't get me started on this one",
+          "bat\tcontains", # 2 columns, no comment
+          "bbb", # 1 column, no match type or comment
+        ].join("\n")
+      end
+
+      it "persists the expected records" do
+        expect { import.save }.to change { CompletionDenylistEntry.count }.by(5)
+
+        expect(CompletionDenylistEntry.pluck(:phrase, :match_type, :category, :comment)).to contain_exactly(
+          [" foo", "exact_match", "offensive", "I don't like this word"],
+          ["bar ", "contains", "offensive", "I like this word even less"],
+          ["baz", "contains", "offensive", "Don't get me started on this one"],
+          ["bat", "contains", "offensive", nil],
+          ["bbb", "exact_match", "offensive", nil],
+        )
+      end
+    end
+
+    context "with comma-delimited input" do
+      let(:denylist_csv_data) do
+        [
+          " foo,exact_match,I don't like this word",
+          "bar ,contains,I like this word even less",
+          "baz,CONTAINS,Don't get me started on this one",
+          "bat,contains", # 2 columns, no comment
+          "bbb", # 1 column, no match type or comment
+        ].join("\n")
+      end
+
+      it "persists the expected records" do
+        expect { import.save }.to change { CompletionDenylistEntry.count }.by(5)
+
+        expect(CompletionDenylistEntry.pluck(:phrase, :match_type, :category, :comment)).to contain_exactly(
+          [" foo", "exact_match", "offensive", "I don't like this word"],
+          ["bar ", "contains", "offensive", "I like this word even less"],
+          ["baz", "contains", "offensive", "Don't get me started on this one"],
+          ["bat", "contains", "offensive", nil],
+          ["bbb", "exact_match", "offensive", nil],
+        )
+      end
+    end
+
+    context "with invalid raw input" do
+      let(:denylist_csv_data) do
+        [
+          "foo,exact_match,I am the only valid record",
+          " ,contains,I have no phrase",
+          "bar,contains,I have an extra column,OMG",
+        ].join("\n")
+      end
+
+      it "does not persist any records, even valid ones" do
+        expect { import.save }.not_to(change { CompletionDenylistEntry.count })
+
+        expect(import.errors.messages_for(:denylist_csv_data)).to contain_exactly(
+          "contains invalid entry ' ,contains,I have no phrase' (does not contain a phrase)",
+          "contains invalid entry 'bar,contains,I have an extra column,OMG' (has an unexpected number of columns)",
+        )
+      end
+    end
+
+    context "with valid raw input that fails CompletionDenylistEntry validation" do
+      let!(:existing_entry) { create(:completion_denylist_entry, phrase: "baz") }
+      let(:denylist_csv_data) do
+        [
+          "foo,exact_match,I am the only valid record",
+          "bar,blub,Invalid match type",
+          "baz,contains,Duplicate entry",
+        ].join("\n")
+      end
+
+      it "does not persist any records, even valid ones" do
+        expect { import.save }.not_to(change { CompletionDenylistEntry.count })
+
+        expect(import.errors.count).to eq(2)
+      end
+    end
+
+    context "with valid input that would take the total count over the limit" do
+      let(:denylist_csv_data) do
+        [
+          "foo,exact_match",
+          "bar,contains",
+        ].join("\n")
+      end
+
+      before do
+        # Assuming the limit is 1 for this test
+        stub_const("CompletionDenylistEntry::MAX_ENTRIES", 1)
+      end
+
+      it "does not persist any records" do
+        expect { import.save }.not_to(change { CompletionDenylistEntry.count })
+
+        expect(import.errors.messages_for(:denylist_csv_data)).to contain_exactly(
+          "would exceed the maximum number of entries (1)",
+        )
+      end
+    end
+
+    context "without any input" do
+      let(:denylist_csv_data) { "\n\n  \n" }
+
+      it "does not persist any records" do
+        expect { import.save }.not_to(change { CompletionDenylistEntry.count })
+
+        expect(import.errors).to be_of_kind(:denylist_csv_data, :blank)
+      end
+    end
+  end
+end

--- a/spec/system/completion_denylist_entries_spec.rb
+++ b/spec/system/completion_denylist_entries_spec.rb
@@ -1,0 +1,181 @@
+RSpec.describe "Completion denylist entries", type: :system do
+  scenario "Viewing denylist entries" do
+    given_several_completion_denylist_entries_exist
+
+    when_i_visit_the_completion_denylist_entries_page
+    then_i_should_see_the_general_completion_denylist_entry
+
+    when_i_select_the_names_tab
+    then_i_should_see_the_name_completion_denylist_entry
+  end
+
+  scenario "Editing an existing denylist entry" do
+    given_an_offensive_completion_denylist_entry
+
+    when_i_visit_the_completion_denylist_entries_page
+    and_i_select_the_offensive_tab
+    and_i_choose_to_edit_the_completion_denylist_entry
+    and_i_submit_the_form_with_updated_details
+
+    then_the_completion_denylist_entry_has_been_updated
+    and_i_can_see_the_updated_details
+  end
+
+  scenario "Attempting to edit a denylist entry with invalid data" do
+    given_an_offensive_completion_denylist_entry
+
+    when_i_visit_the_completion_denylist_entries_page
+    and_i_select_the_offensive_tab
+    and_i_choose_to_edit_the_completion_denylist_entry
+    and_i_submit_the_form_with_invalid_details
+
+    then_the_completion_denylist_entry_has_not_been_updated
+    and_i_can_see_what_errors_i_need_to_fix
+  end
+
+  scenario "Creating a new denylist entry" do
+    when_i_visit_the_completion_denylist_entries_page
+    and_i_choose_to_add_a_new_entry
+    and_i_submit_the_form_with_valid_details
+
+    then_i_should_see_the_new_completion_denylist_entry
+  end
+
+  scenario "Attempting to create a denylist entry with invalid data" do
+    when_i_visit_the_completion_denylist_entries_page
+    and_i_choose_to_add_a_new_entry
+    and_i_submit_the_form_with_invalid_details
+
+    then_the_completion_denylist_entry_has_not_been_created
+    and_i_can_see_what_errors_i_need_to_fix
+  end
+
+  scenario "Deleting an existing denylist entry" do
+    given_an_offensive_completion_denylist_entry
+
+    when_i_visit_the_completion_denylist_entries_page
+    and_i_select_the_offensive_tab
+    and_i_choose_to_edit_the_completion_denylist_entry
+    and_i_choose_to_delete_the_completion_denylist_entry
+
+    then_the_completion_denylist_entry_has_been_deleted
+  end
+
+  def given_several_completion_denylist_entries_exist
+    @completion_denylist_entry_general = create(
+      :completion_denylist_entry,
+      phrase: "foobar",
+      match_type: :contains,
+      category: :general,
+    )
+    @completion_denylist_entry_name = create(
+      :completion_denylist_entry,
+      phrase: "jim hacker",
+      match_type: :exact_match,
+      category: :names,
+    )
+  end
+
+  def given_an_offensive_completion_denylist_entry
+    @offensive_completion_denylist_entry = create(
+      :completion_denylist_entry,
+      phrase: "wagile",
+      match_type: :contains,
+      category: :offensive,
+    )
+  end
+
+  def when_i_visit_the_completion_denylist_entries_page
+    visit completion_denylist_entries_path
+  end
+
+  def when_i_select_the_names_tab
+    click_on "Names"
+  end
+
+  def and_i_select_the_offensive_tab
+    click_on "Offensive"
+  end
+
+  def and_i_choose_to_edit_the_completion_denylist_entry
+    click_on @offensive_completion_denylist_entry.phrase
+  end
+
+  def and_i_submit_the_form_with_updated_details
+    fill_in "Phrase", with: "scrum"
+    fill_in "Comment", with: "No better than PRINCE2"
+    choose "Exact match"
+
+    click_on "Save denylist entry"
+  end
+
+  def and_i_choose_to_add_a_new_entry
+    click_on "New denylist entry"
+  end
+
+  def and_i_submit_the_form_with_valid_details
+    choose "Names"
+    fill_in "Phrase", with: "foobar"
+    fill_in "Comment", with: "This is a test entry"
+    choose "Contains"
+
+    click_on "Save denylist entry"
+  end
+
+  def and_i_submit_the_form_with_invalid_details
+    fill_in "Phrase", with: ""
+
+    click_on "Save denylist entry"
+  end
+
+  def and_i_can_see_what_errors_i_need_to_fix
+    expect(page).to have_content("Phrase can't be blank")
+  end
+
+  def and_i_choose_to_delete_the_completion_denylist_entry
+    click_on "Delete"
+  end
+
+  def then_i_should_see_the_general_completion_denylist_entry
+    expect(page).to have_selector("td", text: "foobar")
+  end
+
+  def then_i_should_see_the_name_completion_denylist_entry
+    expect(page).to have_selector("td", text: "jim⎵hacker")
+  end
+
+  def then_the_completion_denylist_entry_has_been_updated
+    @offensive_completion_denylist_entry.reload
+
+    expect(@offensive_completion_denylist_entry.phrase).to eq("scrum")
+    expect(@offensive_completion_denylist_entry.comment).to eq("No better than PRINCE2")
+    expect(@offensive_completion_denylist_entry.match_type).to eq("exact_match")
+    expect(@offensive_completion_denylist_entry.category).to eq("offensive")
+  end
+
+  def then_the_completion_denylist_entry_has_not_been_updated
+    @offensive_completion_denylist_entry.reload
+
+    expect(@offensive_completion_denylist_entry.phrase).to eq("wagile")
+  end
+
+  def then_the_completion_denylist_entry_has_not_been_created
+    expect(CompletionDenylistEntry.count).to be_zero
+  end
+
+  def and_i_can_see_the_updated_details
+    expect(page).to have_selector("td", text: "scrumNo better than PRINCE2")
+    expect(page).to have_selector("td", text: "Exact match")
+  end
+
+  def then_i_should_see_the_new_completion_denylist_entry
+    expect(page).to have_selector("td", text: "foobarThis is a test entry")
+    expect(page).to have_selector("td", text: "Contains")
+  end
+
+  def then_the_completion_denylist_entry_has_been_deleted
+    expect(CompletionDenylistEntry.exists?(@offensive_completion_denylist_entry.id)).to eq(false)
+    expect(page).not_to have_selector("td", text: "wagile")
+    expect(page).to have_content("The denylist entry was successfully deleted.")
+  end
+end


### PR DESCRIPTION
Adds the ability to manage entries on the Discovery Engine completion denylist.

The completion denylist allows us to specify terms that should never be suggested to users in the autocomplete dropdown when typing a search query, and is currently manually managed as a Google Sheet.

This adds:
* a `CompletionDenylistEntry` model to track entries sorted in categories
* a basic CRUD UI to list and manage entries (without a separate `show` action to keep things simple)
* an import tool that allows administrators to add several entries in one go, in particular by copying and pasting from a Google Sheet

_Note that this PR intentionally does not yet synchronise to Discovery Engine. This will be a subsequent PR so that we have a chance to import the existing denylist into Search Admin without accidentally overwriting the data that's already in Discovery Engine._

## Screenshots
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/6ae530a0-be2f-416d-8a72-b934baf9fdfb" />

---

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/bc566c22-cb54-4613-9530-43c8a8f81355" />

---

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/a9493c44-95e0-43d5-a194-0b6afca72fb6" />
