### PR TITLE
Completion denylist: Add synchronisation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "google-cloud-discovery_engine-v1beta"
 gem "mysql2"
 gem "sentry-sidekiq"
 gem "sprockets-rails"
+gem "with_advisory_lock"
 
 # GDS managed gems
 gem "gds-api-adapters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -762,6 +762,9 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    with_advisory_lock (5.1.0)
+      activerecord (>= 6.1)
+      zeitwerk (>= 2.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.2)
@@ -797,6 +800,7 @@ DEPENDENCIES
   simplecov
   sprockets-rails
   webmock
+  with_advisory_lock
 
 BUNDLED WITH
    2.6.7

--- a/app/clients/discovery_engine/completion_denylist_client.rb
+++ b/app/clients/discovery_engine/completion_denylist_client.rb
@@ -1,0 +1,44 @@
+module DiscoveryEngine
+  # Client to synchronise completion denylist entries to Discovery Engine
+  #
+  # Discovery Engine does not support operating on individual denylist entries, instead any changes
+  # to existing items on the denylist require a full import.
+  #
+  # This client's operations are normally asynchronous, but it intentionally blocks while waiting
+  # for a result to make error reporting easier. It should only be used in a background job or
+  # scheduled task.
+  class CompletionDenylistClient
+    include DiscoveryEngine::Services
+
+    # Imports a list/scope of `CompletionDenylistEntry` records to Discovery Engine
+    def import(completion_denylist_entries)
+      operation = completion_service.import_suggestion_deny_list_entries(
+        inline_source: {
+          # This isn't the most efficient way of doing this, but given that the current maximum
+          # number of denylist entries in Discovery Engine is the same as `#find_each`'s default
+          # batch size (1000), it's not the end of the world even if we pass in the whole of
+          # `DenylistEntry` as a scope.
+          #
+          # If that ever goes up by an order of magnitude, we should consider making this more
+          # efficient, for example by selecting the required columns instead of dealing with
+          # ActiveRecord objects.
+          entries: completion_denylist_entries.map(
+            &:to_discovery_engine_completion_denylist_entry
+          ),
+        },
+        parent: DataStore.default.name,
+      )
+
+      operation.wait_until_done!
+      raise operation.results.message if operation.error?
+
+      failed = operation.results.failed_entries_count
+      imported = operation.results.imported_entries_count
+      if failed.positive?
+        raise "Failed to import #{failed} entries to completion denylist (#{imported} succeeded)"
+      end
+
+      Rails.logger.info("Successfully imported #{imported} entries to completion denylist")
+    end
+  end
+end

--- a/app/clients/discovery_engine/services.rb
+++ b/app/clients/discovery_engine/services.rb
@@ -5,6 +5,11 @@ require "google/cloud/discovery_engine/v1beta"
 module DiscoveryEngine
   # Mixin providing access to the Discovery Engine API client's services
   module Services
+    # Returns a Discovery Engine client for the completion service
+    def completion_service
+      @completion_service ||= Google::Cloud::DiscoveryEngine.completion_service(version: :v1)
+    end
+
     # Returns a Discovery Engine client for the control service
     def control_service
       @control_service ||= Google::Cloud::DiscoveryEngine.control_service(version: :v1)

--- a/app/controllers/completion_denylist_entries_controller.rb
+++ b/app/controllers/completion_denylist_entries_controller.rb
@@ -21,6 +21,7 @@ class CompletionDenylistEntriesController < ApplicationController
     @completion_denylist_entry = CompletionDenylistEntry.new(completion_denylist_entry_params)
 
     if @completion_denylist_entry.save
+      ImportCompletionDenylistWorker.perform_async
       redirect_to completion_denylist_entries_path(category: @completion_denylist_entry.category), notice: t(".success")
     else
       render :new
@@ -33,6 +34,7 @@ class CompletionDenylistEntriesController < ApplicationController
     @completion_denylist_entry.assign_attributes(completion_denylist_entry_params)
 
     if @completion_denylist_entry.save
+      ImportCompletionDenylistWorker.perform_async
       redirect_to completion_denylist_entries_path(category: @completion_denylist_entry.category), notice: t(".success")
     else
       render :edit
@@ -41,6 +43,7 @@ class CompletionDenylistEntriesController < ApplicationController
 
   def destroy
     if @completion_denylist_entry.destroy
+      ImportCompletionDenylistWorker.perform_async
       redirect_to completion_denylist_entries_path(category: @completion_denylist_entry.category), notice: t(".success")
     else
       redirect_to completion_denylist_entries_path(category: @completion_denylist_entry.category), alert: t(".failure")

--- a/app/controllers/completion_denylist_entry_imports_controller.rb
+++ b/app/controllers/completion_denylist_entry_imports_controller.rb
@@ -11,6 +11,7 @@ class CompletionDenylistEntryImportsController < ApplicationController
     @completion_denylist_entry_import = CompletionDenylistEntryImport.new(completion_denylist_entry_import_params)
 
     if @completion_denylist_entry_import.save
+      ImportCompletionDenylistWorker.perform_async
       redirect_to(
         completion_denylist_entries_path(category: @completion_denylist_entry_import.category),
         notice: t(".success", count: @completion_denylist_entry_import.records.size),

--- a/app/models/completion_denylist_entry.rb
+++ b/app/models/completion_denylist_entry.rb
@@ -20,6 +20,13 @@ class CompletionDenylistEntry < ApplicationRecord
   normalizes :phrase, with: ->(phrase) { phrase.downcase }
   validate :does_not_exceed_maximum_entries
 
+  def to_discovery_engine_completion_denylist_entry
+    {
+      block_phrase: phrase,
+      match_operator: match_type.upcase,
+    }
+  end
+
 private
 
   def does_not_exceed_maximum_entries

--- a/app/workers/import_completion_denylist_worker.rb
+++ b/app/workers/import_completion_denylist_worker.rb
@@ -1,0 +1,17 @@
+class ImportCompletionDenylistWorker
+  LOCK_NAME = "import_completion_denylist_worker".freeze
+
+  include Sidekiq::Worker
+
+  def perform
+    CompletionDenylistEntry.with_advisory_lock(LOCK_NAME) do
+      client.import(CompletionDenylistEntry.all)
+    end
+  end
+
+private
+
+  def client
+    @client ||= DiscoveryEngine::CompletionDenylistClient.new
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -237,13 +237,18 @@ en:
     new:
       page_title: New denylist entry
     create:
-      success: The denylist entry was successfully created.
+      success: >-
+        The denylist entry was successfully created. It may take several minutes for the changes to
+        be processed by Vertex AI Search.
     edit:
       page_title: Edit %{phrase}
     update:
-      success: The denylist entry was successfully updated.
+      success: >-
+        The denylist entry was successfully updated. It may take several minutes for the changes to
+        be processed by Vertex AI Search.
     destroy:
-      success: The denylist entry was successfully deleted.
+      success: >-
+        The denylist entry was successfully deleted. It may take several minutes for the changes to be processed by Vertex AI Search.
       failure: The denylist entry could not be deleted.
 
   completion_denylist_entry_imports:

--- a/lib/tasks/completion.rake
+++ b/lib/tasks/completion.rake
@@ -1,0 +1,9 @@
+namespace :completion do
+  # This worker normally runs after changes are made to CompletionDenylistEntry records, but we may
+  # want to run it manually, for example after a database import from a higher environment.
+  desc "Trigger a denylist import to Discovery Engine"
+  task import_denylist: :environment do
+    # Run worker inline instead of async so we can get immediate feedback on any errors
+    ImportCompletionDenylistWorker.new.perform
+  end
+end

--- a/spec/clients/discovery_engine/completion_denylist_client_spec.rb
+++ b/spec/clients/discovery_engine/completion_denylist_client_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe DiscoveryEngine::CompletionDenylistClient, type: :client do
+  let(:discovery_engine_client) do
+    instance_double(
+      Google::Cloud::DiscoveryEngine::V1::CompletionService::Client,
+      import_suggestion_deny_list_entries: operation,
+    )
+  end
+  let(:operation) { double("operation", wait_until_done!: true, error?: error, results:) }
+  let(:error) { false }
+
+  before do
+    allow(Google::Cloud::DiscoveryEngine)
+      .to receive(:completion_service).and_return(discovery_engine_client)
+  end
+
+  describe "#import" do
+    let(:completion_denylist_entries) { [entry] }
+    let(:entry) do
+      instance_double(
+        CompletionDenylistEntry,
+        to_discovery_engine_completion_denylist_entry: { foo: "bar" },
+      )
+    end
+    let(:results) { double("results", failed_entries_count: 0, imported_entries_count: 42) }
+
+    it "imports the denylist entries to Discovery Engine" do
+      subject.import(completion_denylist_entries)
+
+      expect(discovery_engine_client).to have_received(:import_suggestion_deny_list_entries).with(
+        inline_source: {
+          entries: [{ foo: "bar" }],
+        },
+        parent: DataStore.default.name,
+      )
+    end
+
+    it "waits for the operation to complete" do
+      subject.import(completion_denylist_entries)
+
+      expect(operation).to have_received(:wait_until_done!)
+    end
+
+    context "when the import fails outright" do
+      let(:error) { true }
+      let(:results) { double("results", message: "Import failed") }
+
+      it "raises an error" do
+        expect { subject.import(completion_denylist_entries) }
+          .to raise_error("Import failed")
+      end
+    end
+
+    context "when some entries fail to import" do
+      let(:results) { double("results", failed_entries_count: 19, imported_entries_count: 89) }
+
+      it "raises an error" do
+        expect { subject.import(completion_denylist_entries) }
+          .to raise_error("Failed to import 19 entries to completion denylist (89 succeeded)")
+      end
+    end
+  end
+end

--- a/spec/models/completion_denylist_entry_spec.rb
+++ b/spec/models/completion_denylist_entry_spec.rb
@@ -108,4 +108,17 @@ RSpec.describe CompletionDenylistEntry, type: :model do
       end
     end
   end
+
+  describe "#to_discovery_engine_completion_denylist_entry" do
+    subject(:completion_denylist_entry) do
+      build(:completion_denylist_entry, phrase: "oh, block it all out", match_type: :exact_match)
+    end
+
+    it "returns the completion denylist entry as a hash with the expected format" do
+      expect(completion_denylist_entry.to_discovery_engine_completion_denylist_entry).to eq(
+        block_phrase: "oh, block it all out",
+        match_operator: "EXACT_MATCH",
+      )
+    end
+  end
 end

--- a/spec/system/completion_denylist_entries_spec.rb
+++ b/spec/system/completion_denylist_entries_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Completion denylist entries", type: :system do
     and_i_submit_the_form_with_updated_details
 
     then_the_completion_denylist_entry_has_been_updated
+    and_an_import_to_discovery_engine_has_been_triggered
     and_i_can_see_the_updated_details
   end
 
@@ -30,6 +31,7 @@ RSpec.describe "Completion denylist entries", type: :system do
     and_i_submit_the_form_with_invalid_details
 
     then_the_completion_denylist_entry_has_not_been_updated
+    and_an_import_to_discovery_engine_has_not_been_triggered
     and_i_can_see_what_errors_i_need_to_fix
   end
 
@@ -39,6 +41,7 @@ RSpec.describe "Completion denylist entries", type: :system do
     and_i_submit_the_form_with_valid_details
 
     then_i_should_see_the_new_completion_denylist_entry
+    and_an_import_to_discovery_engine_has_been_triggered
   end
 
   scenario "Attempting to create a denylist entry with invalid data" do
@@ -47,6 +50,7 @@ RSpec.describe "Completion denylist entries", type: :system do
     and_i_submit_the_form_with_invalid_details
 
     then_the_completion_denylist_entry_has_not_been_created
+    and_an_import_to_discovery_engine_has_not_been_triggered
     and_i_can_see_what_errors_i_need_to_fix
   end
 
@@ -59,6 +63,7 @@ RSpec.describe "Completion denylist entries", type: :system do
     and_i_choose_to_delete_the_completion_denylist_entry
 
     then_the_completion_denylist_entry_has_been_deleted
+    and_an_import_to_discovery_engine_has_been_triggered
   end
 
   scenario "Importing denylist entries" do
@@ -67,6 +72,7 @@ RSpec.describe "Completion denylist entries", type: :system do
     and_i_submit_the_form_with_valid_csv_entries
 
     then_the_new_entries_have_been_imported
+    and_an_import_to_discovery_engine_has_been_triggered
   end
 
   scenario "Attempting to import denylist entries with invalid data" do
@@ -75,6 +81,7 @@ RSpec.describe "Completion denylist entries", type: :system do
     and_i_submit_the_form_with_invalid_csv_entries
 
     then_the_new_entries_have_not_been_imported
+    and_an_import_to_discovery_engine_has_not_been_triggered
     and_i_can_see_what_errors_i_need_to_fix_in_the_csv
   end
 
@@ -194,10 +201,18 @@ RSpec.describe "Completion denylist entries", type: :system do
     expect(@offensive_completion_denylist_entry.category).to eq("offensive")
   end
 
+  def and_an_import_to_discovery_engine_has_been_triggered
+    expect(ImportCompletionDenylistWorker.jobs.size).to be_positive
+  end
+
   def then_the_completion_denylist_entry_has_not_been_updated
     @offensive_completion_denylist_entry.reload
 
     expect(@offensive_completion_denylist_entry.phrase).to eq("wagile")
+  end
+
+  def and_an_import_to_discovery_engine_has_not_been_triggered
+    expect(ImportCompletionDenylistWorker.jobs.size).to be_zero
   end
 
   def then_the_completion_denylist_entry_has_not_been_created

--- a/spec/workers/import_completion_denylist_worker_spec.rb
+++ b/spec/workers/import_completion_denylist_worker_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe ImportCompletionDenylistWorker do
+  describe "#perform" do
+    let(:entries) { [double("entry1"), double("entry2")] }
+    let(:client) { instance_double(DiscoveryEngine::CompletionDenylistClient, import: true) }
+
+    before do
+      allow(DiscoveryEngine::CompletionDenylistClient).to receive(:new).and_return(client)
+      allow(CompletionDenylistEntry).to receive(:all).and_return(entries)
+      allow(CompletionDenylistEntry).to receive(:with_advisory_lock).and_yield
+    end
+
+    it "acquires a lock" do
+      subject.perform
+
+      expect(CompletionDenylistEntry).to have_received(:with_advisory_lock)
+    end
+
+    it "syncs all denylist entries to Discovery Engine using the client" do
+      subject.perform
+
+      expect(client).to have_received(:import).with(entries)
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability for Search Admin to synchronise denylist entries to Discovery Engine when changes are made.

- Add `with_advisory_lock` gem for locking along the lines of other GOV.UK apps
- Add a Discovery Engine API representation to `CompletionDenylistEntry`
- Add a `CompletionDenylistClient` to run the remote import operation
- Add a `ImportCompletionDenylistWorker` that uses the client to import all denylist entries under locking, and trigger it when changes are made
- Add a Rake task to manually trigger import if necessary (e.g. after database backup restore on non-production environments)