### PR TITLE
Use v1 serving config service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem "bootsnap", require: false
 gem "csv"
 gem "dartsass-rails"
 gem "google-cloud-discovery_engine"
-gem "google-cloud-discovery_engine-v1beta"
 gem "mysql2"
 gem "sentry-sidekiq"
 gem "sprockets-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,10 +164,6 @@ GEM
       gapic-common (>= 0.25.0, < 2.a)
       google-cloud-errors (~> 1.0)
       google-cloud-location (>= 0.7, < 2.a)
-    google-cloud-discovery_engine-v1beta (0.19.0)
-      gapic-common (>= 0.25.0, < 2.a)
-      google-cloud-errors (~> 1.0)
-      google-cloud-location (>= 0.7, < 2.a)
     google-cloud-env (2.2.2)
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
@@ -778,7 +774,6 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso
   google-cloud-discovery_engine
-  google-cloud-discovery_engine-v1beta
   govuk_app_config
   govuk_publishing_components
   govuk_schemas

--- a/app/clients/discovery_engine/services.rb
+++ b/app/clients/discovery_engine/services.rb
@@ -1,7 +1,3 @@
-# Unlike the main `Google::Cloud::DiscoveryEngine` entrypoint, the beta libraries are not required
-# by default and need manual loading. Remove this when we no longer need v1beta.
-require "google/cloud/discovery_engine/v1beta"
-
 module DiscoveryEngine
   # Mixin providing access to the Discovery Engine API client's services
   module Services
@@ -12,15 +8,9 @@ module DiscoveryEngine
 
     # Returns a Discovery Engine client for the serving config service
     def serving_config_service
-      # TODO: As of version 2.0 of the Discovery Engine client, beta services can no longer be
-      # initialized using the main entrypoint, so we need to manually instantiate a beta service
-      # client instance. Once the serving config service graduates into `v1`, we should use this
-      # instead:
-      # ```
-      # Google::Cloud::DiscoveryEngine.serving_config_service(version: :v1)
-      # ```
-      @serving_config_service ||= Google::Cloud::DiscoveryEngine::V1beta::
-                                    ServingConfigService::Client.new
+      @serving_config_service ||= Google::Cloud::DiscoveryEngine.serving_config_service(
+        version: :v1,
+      )
     end
   end
 end

--- a/spec/clients/discovery_engine/serving_config_client_spec.rb
+++ b/spec/clients/discovery_engine/serving_config_client_spec.rb
@@ -3,14 +3,14 @@ RSpec.describe DiscoveryEngine::ServingConfigClient do
 
   let(:discovery_engine_client) do
     instance_double(
-      Google::Cloud::DiscoveryEngine::V1beta::ServingConfigService::Client,
+      Google::Cloud::DiscoveryEngine::V1::ServingConfigService::Client,
       update_serving_config: true,
     )
   end
 
   before do
-    allow(Google::Cloud::DiscoveryEngine::V1beta::ServingConfigService::Client)
-      .to receive(:new).and_return(discovery_engine_client)
+    allow(Google::Cloud::DiscoveryEngine)
+      .to receive(:serving_config_service).and_return(discovery_engine_client)
   end
 
   describe "#update" do


### PR DESCRIPTION
This is now available in v1, and no longer needs the manual loading and faffing around with the v1beta service client.