### PR TITLE
Use CSS instead of text replacement to highlight spaces

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,3 +57,14 @@
   color: govuk-colour("dark-grey");
   font-style: italic;
 }
+
+// Show spaces in denylist entries using a special character to make them more obvious
+.app-denylist-entry-visible-space {
+  font-size: 0;
+
+  &::before {
+    content: "⎵";
+    font-size: 1rem;
+    color: govuk-colour("dark-grey");
+  }
+}

--- a/app/helpers/completion_denylist_entries_helper.rb
+++ b/app/helpers/completion_denylist_entries_helper.rb
@@ -6,7 +6,8 @@ module CompletionDenylistEntriesHelper
   }.freeze
 
   def completion_denylist_entry_phrase_with_visible_spaces(completion_denylist_entry)
-    completion_denylist_entry.phrase.gsub(/\s/, "⎵")
+    space = tag.span(" ", class: "app-denylist-entry-visible-space")
+    completion_denylist_entry.phrase.gsub(/\s/, space).html_safe
   end
 
   def completion_denylist_entry_match_type_tag(completion_denylist_entry)

--- a/spec/helpers/completion_denylist_entries_helper_spec.rb
+++ b/spec/helpers/completion_denylist_entries_helper_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe CompletionDenylistEntriesHelper do
+  describe "#completion_denylist_entry_phrase_with_visible_spaces" do
+    subject { helper.completion_denylist_entry_phrase_with_visible_spaces(completion_denylist_entry) }
+
+    let(:completion_denylist_entry) { build(:completion_denylist_entry, phrase: "evil phrase") }
+
+    it { is_expected.to eq("evil<span class=\"app-denylist-entry-visible-space\"> </span>phrase") }
+  end
+end

--- a/spec/system/completion_denylist_entries_spec.rb
+++ b/spec/system/completion_denylist_entries_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe "Completion denylist entries", type: :system do
   end
 
   def then_i_should_see_the_name_completion_denylist_entry
-    expect(page).to have_selector("td", text: "jim⎵hacker")
+    expect(page).to have_selector("td", text: "jim hacker")
   end
 
   def then_the_completion_denylist_entry_has_been_updated


### PR DESCRIPTION
This uses (slightly hacky) CSS instead of text replacement to highlight spaces contained in denylist entry phrases. This allows users to actually search for entries containing space characters, and makes the UI more accessible to boot.

<img width="991" alt="image" src="https://github.com/user-attachments/assets/6b09347e-ed29-439e-8bd0-b476de5f8638" />
