### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,1 @@
-version: 2
-updates:
-  - package-ecosystem: bundler
-    directory: /
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily
+---


### PR DESCRIPTION
Disable Dependabot for all dependencies while the npmjs security incident is ongoing