### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,25 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
+      exclude:
+        - gds-api-adapters
+        - gds-sso
+        - govuk_app_config
+        - govuk_publishing_components
+        - govuk_sidekiq
+        - govuk_schemas
+        - govuk_test
+        - plek
+        - rubocop-govuk
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
     ignore:
       - dependency-name: ruby
 
@@ -16,8 +30,12 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Setting to 3 days as per the [suggested configuration](https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#schedule-and-cooldown)

Excluding internal dependencies, as they will have their own cooldown configured.

[Jira ticket SCH-2043](https://gov-uk.atlassian.net/browse/SCH-2043)