### PR TITLE
Import 'service navigation' and 'tag' css components

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,11 +17,13 @@
 @import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/search';
 @import 'govuk_publishing_components/components/secondary-navigation';
+@import 'govuk_publishing_components/components/service-navigation';
 @import 'govuk_publishing_components/components/skip-link';
 @import 'govuk_publishing_components/components/success-alert';
 @import 'govuk_publishing_components/components/summary-list';
 @import 'govuk_publishing_components/components/table';
 @import 'govuk_publishing_components/components/tabs';
+@import 'govuk_publishing_components/components/tag';
 @import 'govuk_publishing_components/components/textarea';
 
 .actions {


### PR DESCRIPTION
This fixes an issue where navigation links are not displayed properly

Before:

<img width="1358" height="584" alt="image" src="https://github.com/user-attachments/assets/ca32f1b2-546b-4c71-9b44-b987ca4b536c" />

After:

<img width="1098" height="548" alt="image" src="https://github.com/user-attachments/assets/66dcb1b9-6da7-4510-9348-4a51bace9a69" />


