### PR TITLE
Update naming from Vertex to Agent Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Run `bundle exec rake publish_external_links:publishing_api` to send all externa
 
 ### Document rake tasks
 
-These rake tasks connect to Google Cloud Platform (GCP) to interact with documents stored in the Discovery Engine datastore.
+These rake tasks use Google Cloud Discovery Engine API to interact with documents in the Agent Search Datastore.
 
 Authentication is required:
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,7 +134,7 @@ en:
       models:
         completion_denylist_entry:
           too_many_entries: >
-            Vertex AI Search maximum denylist entry limit reached. You can only have
+            Agent Search maximum denylist entry limit reached. You can only have
             %{max_entries}.
 
   completion_denylist_entries:
@@ -150,16 +150,16 @@ en:
     create:
       success: >-
         The denylist entry was successfully created. It may take several minutes for the changes to
-        be processed by Vertex AI Search.
+        be processed by Agent Search.
     edit:
       page_title: Edit %{phrase}
     update:
       success: >-
         The denylist entry was successfully updated. It may take several minutes for the changes to
-        be processed by Vertex AI Search.
+        be processed by Agent Search.
     destroy:
       success: >-
-        The denylist entry was successfully deleted. It may take several minutes for the changes to be processed by Vertex AI Search.
+        The denylist entry was successfully deleted. It may take several minutes for the changes to be processed by Agent Search.
       failure: The denylist entry could not be deleted.
 
   completion_denylist_entry_imports:

--- a/lib/tasks/document.rake
+++ b/lib/tasks/document.rake
@@ -5,14 +5,14 @@ namespace :document do
   # deleted through the normal channels. This can happen when someone deletes a document
   # directly from the Publishing API database without firing the callbacks that trigger
   # a message queue unpublish message.
-  desc "Delete a specific document from Google Vertex Datastore"
+  desc "Delete a specific document from Google Cloud Agent Search Datastore"
   task :delete_document, [:content_id] => :environment do |_, args|
     raise ArgumentError, "Content ID is required" if args[:content_id].nil?
 
     DiscoveryEngine::DocumentServiceClient.new.delete_document(content_id: args[:content_id])
   end
 
-  desc "Get a specific document from Google Vertex Datastore"
+  desc "Get a specific document from Google Cloud Agent Search Datastore"
   task :get_document, [:content_id] => :environment do |_, args|
     raise ArgumentError, "Content ID is required" if args[:content_id].nil?
 


### PR DESCRIPTION
Google have rebranded Vertex AI Search to Agent Search, so we need to update the docs to reflect this.

Because search-admin is used by stakeholders other than developers, I'm using the marketing name "Agent Search" rather than the API name "Discovery Engine". In other repos, where the main points of interaction will be with developers, we use the more technical and stable API name.

Jira link: https://gov-uk.atlassian.net/browse/SCH-2050